### PR TITLE
Допил Ламии v1.1

### DIFF
--- a/common/event_modifiers/BR_lahmia.csv
+++ b/common/event_modifiers/BR_lahmia.csv
@@ -1,0 +1,13 @@
+great_city;Great Lahmia;;;;;;;;;;;;x
+great_city_desc;Reconstructed Lahmia. Beautiful palace, looks like majestic citadel. Ancient temple of Blood recreated in its former glory and destination.;;;;;;;;;;;;x
+retake_lahmia;The lahmia returns!;;;;;;;;;;;;;x
+retake_lahmia_desc;Our homeland is ours finally!Glory to queen!.;;;;;;;;;;;;;x
+rebuild_palace_and_blood_temple;It is time to reconstruct our ancient capital.;;;;;;;;;;;;;x
+rebuild_palace_and_blood_temple_desc;Reconstruct whole city Lahmia, graceful palace, and temple of Blood;;;;;;;;;;;;;x
+cleanse_nehekharan_curse;Cleanse sand curse;;;;;;;;;;;;;x
+cleanse_nehekharan_curse_desc;This lands are cursed by old necromantic magic, undead is just rises from sand. In our powers to stop it forever.;;;;;;;;;;;;;x
+EVTDESC_cleanse_nehekharan_curse_marshal_liege;With necromantic powers, you can dispell old magic of Nagash in this region to stop infinite rises of undead from sand.;;;;;;;;;;;;;;
+EVTOPTA_cleanse_nehekharan_curse_marshal_liege;It is time.;;;;;;;;;;;;;;
+EVTOPTB_cleanse_nehekharan_curse_marshal_liege;Not now.;;;;;;;;;;;;;;
+EVTDESC_cleanse_nehekharan_curse_success;Dark rituals has do their work. The undead are resting.;;;;;;;;;;;;;;
+EVTOPTA_cleanse_nehekharan_curse_success;Great work has done.;;;;;;;;;;;;;;

--- a/common/event_modifiers/BR_lahmian_decisions.txt
+++ b/common/event_modifiers/BR_lahmian_decisions.txt
@@ -1,0 +1,372 @@
+targetted_decisions = {
+
+send_a_seductress = {
+	ai_target_filter = spouse ##only players use this mechanic, since filter all is too CPU intensive. AI will use other mechanics
+	from_potential = {
+		ai = no
+		trait = lahmian_queen
+		any_dynasty_member ={
+		AND = {
+		is_female = yes
+		is_landed = no
+		trait = vampire_lahmian_visible
+		NOT = { trait = on_lahmian_mission }
+		}
+	}
+	}
+	
+	potential = {
+		is_playable = yes
+		is_female = no
+		higher_tier_than = BARON
+		is_within_diplo_range = FROM
+		age = 16
+		NOT = { has_character_flag = lahmian_target }
+		NOT = { is_lover = FROM }
+		trait = creature_human
+	}
+	
+	allow = {
+		FROM = { wealth = 25 }
+	}
+	
+	effect = {
+		character_event = { id = lahmia.7 }
+		#set_character_flag = temp_lahmian_target
+		#FROM = { character_event = { id = lahmia.5  } }
+	}
+	
+	ai_will_do = {
+		factor = 0
+	}
+}
+
+seduce_target_personally = {
+	ai_target_filter = spouse ##only players use this mechanic, since filter all is too CPU intensive. AI will use other mechanics
+	from_potential = {
+		ai = no
+		AND = {
+		trait = lahmian_queen
+		trait = vampire_lahmian_visible
+		NOT = { trait = on_lahmian_mission }
+		}
+		}
+	
+	potential = {
+			custom_tooltip = { text = IS_NOT_INCAPACITATED
+					is_incapacitated_trigger = no }
+		is_playable = yes
+		is_female = no
+		higher_tier_than = BARON
+		is_within_diplo_range = FROM
+		age = 16
+		NOT = { has_character_flag = lahmian_target }
+		NOT = { is_lover = FROM }
+		trait = creature_human
+	}
+	
+	allow = {
+		FROM = { wealth = 25 }
+	}
+	
+	effect = {
+		character_event = { id = lahmia.105 }
+	}
+	
+	ai_will_do = {
+		factor = 0
+	}
+}
+
+recall_from_mission = {
+	ai_target_filter = spouse ##only players use this mechanic, since filter all is too CPU intensive. AI will use other mechanics
+	from_potential = {
+		ai = no
+		AND = {
+		trait = lahmian_queen
+		trait = vampire_lahmian_visible
+		}
+		}
+	
+	potential = {
+		AND = {
+		trait = vampire_lahmian_visible
+		trait = on_lahmian_mission
+		NOT = { has_character_flag = recruitment_mission }
+		}
+	}
+	
+	allow = {
+		always = yes
+	}
+	
+	effect = {
+		set_character_flag = return_home_lahmia
+	}
+	
+	ai_will_do = {
+		factor = 0
+	}
+}
+
+recall_from_recruitment_mission = {
+	ai_target_filter = spouse ##only players use this mechanic, since filter all is too CPU intensive. AI will use other mechanics
+	from_potential = {
+		ai = no
+		AND = {
+		trait = lahmian_queen
+		trait = vampire_lahmian_visible
+		}
+		}
+	
+	potential = {
+		AND = {
+		trait = vampire_lahmian_visible
+		trait = on_lahmian_mission
+		has_character_flag = recruitment_mission
+		}
+	}
+	
+	allow = {
+		always = yes
+	}
+	
+	effect = {
+		clr_character_flag = recruitment_mission
+		remove_trait = on_lahmian_mission
+	}
+	
+	ai_will_do = {
+		factor = 0
+	}
+}
+
+bring_lover_home = {
+	ai_target_filter = spouse ##only players use this mechanic, since filter all is too CPU intensive. AI will use other mechanics
+	from_potential = {
+		ai = no
+		trait = vampire_lahmian_visible
+		}
+	
+	potential = {
+		is_lover = FROM
+		is_landed = no
+		NOT = { same_realm = FROM }
+		trait = creature_human
+		NOT = { religion_group = chaos_gods_group }
+	}
+	
+	allow = {
+		always = yes
+	}
+	
+	effect = {
+		character_event = { id = lahmia.200 }
+	}
+	
+	ai_will_do = {
+		factor = 0
+	}
+}
+
+send_on_recruitment_mission = {
+	ai_target_filter = spouse ##only players use this mechanic, since filter all is too CPU intensive. AI will use other mechanics
+	from_potential = {
+		ai = no
+		trait = vampire_lahmian_visible
+		trait = lahmian_queen
+		any_dynasty_member ={
+		AND = {
+		trait = vampire_lahmian_visible
+		NOT = { trait = on_lahmian_mission }
+		}
+		}
+		}
+	
+	potential = {
+		dynasty = FROM
+		trait = vampire_lahmian_visible
+		NOT = { trait = on_lahmian_mission }
+	}
+	
+	allow = {
+		FROM = { wealth = 10 }
+	}
+	
+	effect = {
+		FROM = { wealth = -10 }
+		add_trait = on_lahmian_mission
+		set_character_flag = recruitment_mission
+	}
+	
+	ai_will_do = {
+		factor = 0
+	}
+}
+
+establish_lahmian_presence = {
+	ai_target_filter = spouse ##only players use this mechanic, since filter all is too CPU intensive. AI will use other mechanics
+	from_potential = {
+		ai = no
+		trait = vampire_lahmian_visible
+		trait = lahmian_queen
+		}
+	
+	potential = {
+		higher_tier_than = BARON
+		is_within_diplo_range = FROM
+		religion_group = old_world_group
+		trait = creature_human
+		location = {
+		NOT = { has_province_modifier = lahmian_presence }
+		}
+	}
+	
+	allow = {
+		FROM = { wealth = 100 }
+	}
+	
+	effect = {
+		FROM = { wealth = -100 }
+		character_event = { id = lahmia.300 }
+	}
+	
+	ai_will_do = {
+		factor = 0
+	}
+}
+}
+
+decisions = {
+retake_lahmia = {
+		is_high_prio = yes
+		only_rulers = yes
+		potential = {
+			age = 16
+			is_ruler = yes
+			higher_tier_than = BARON
+			independent = yes 
+			trait = lahmian_queen	
+			NOT = { has_global_flag = retake_lahmia }
+		}
+		allow = {
+			wealth = 550
+			prestige = 2500
+			piety = 500
+			has_landed_title = k_lahmia
+		}
+		effect = {
+			wealth = -2500
+			piety = 100
+			prestige = 800
+			hidden_tooltip = {
+			set_global_flag = retake_lahmia
+			c_lahmia = { ROOT = { capital = PREV } }
+			give_nickname = nick_the_beautiful_sun
+			 }
+			}
+		revoke_allowed = {
+			always = no
+		}
+		ai_will_do = {
+			factor = 1
+		}
+}
+
+rebuild_palace_and_blood_temple = {
+		is_high_prio = yes
+		only_rulers = yes
+		potential = {
+			age = 16
+			is_ruler = yes
+			higher_tier_than = BARON
+			independent = yes 
+			trait = lahmian_queen	
+			NOT = { has_global_flag = rebuild_palace_and_blood_temple }
+		}
+		allow = {
+			wealth = 500
+			prestige = 1000
+			piety = 200
+			has_landed_title = c_lahmia
+		}
+		effect = {
+			wealth = -1500
+			piety = 500
+			prestige = 1000
+			hidden_tooltip = {
+			set_global_flag = rebuild_palace_and_blood_temple
+		 	1127 = { add_province_modifier = { name = great_city days = -1 }	}
+			 }
+			}
+		revoke_allowed = {
+			always = no
+		}
+		ai_will_do = {
+			factor = 1
+		}
+}
+}
+
+settlement_decisions = {
+
+cleanse_nehekharan_curse = {
+		filter = owned
+		ai_target_filter = owned
+		is_high_prio = yes
+		only_playable = yes
+
+		potential = {
+			FROM = {
+				NOR = {
+					trait = creature_nehekharan
+				}
+			}
+			holder_scope = {
+				character = FROM
+			}
+			dejure_liege_title = {
+				holder_scope = {
+					character = FROM
+				}
+			}
+			OR = {
+				location = { has_province_modifier = nehekharan_curse }
+				location = { culture_group = nehekharan_group }
+			}
+		}
+		allow = {
+			FROM = {
+				trait = lore_necromancy
+				wealth = 200
+			}
+			NOT = { location = { has_province_modifier = cleanse_undead } }
+			OR = {
+				location = { has_province_modifier = nehekharan_curse }
+				location = { culture_group = nehekharan_group }
+			}
+		}
+		effect = {
+			hidden_tooltip = {
+					FROM = { character_event = { id = lahmia.395 } }
+				 	location = {
+						add_province_modifier = {
+							name = cleanse_undead
+							duration = 60
+							hidden = yes
+						}
+					}
+			}
+		}
+
+		revoke_allowed = {
+			always = no
+		}
+
+		ai_will_do = {
+			factor = 1
+
+
+		}
+	}
+}

--- a/common/event_modifiers/BR_lahmian_events.txt
+++ b/common/event_modifiers/BR_lahmian_events.txt
@@ -1,0 +1,5138 @@
+namespace = lahmia
+
+###First a lahmian queen gets intro event
+	long_character_event = {
+	id = lahmia.0
+	title = LIFE_ETERNAL
+	desc = lahmia0desc #You are the Queen of the Lahmians. Your ancient kingdom of Lahmia in Nehekhara was taken from you, but its glories of old can still be restored. Using stealth, cunning, and seduction you can mold the world of men to serve your purposes. Send your daughters into the world, have them infiltrate the corridors of power, and when the time is right - have your mortal puppets dance to the tune that you play for them. Seduce the weak mortals to become your slaves and then one day you shall lead a great army to retake Lahmia and you shall live forever as its queen, with nothing in the world being denied to you.
+	picture = "GFX_vampiress1"
+
+	is_triggered_only = yes
+
+	trigger = {
+	trait = lahmian_queen
+	NOT = { has_character_flag = lahmia0 }
+	NOT = { has_landed_title = k_lahmia }
+	}
+
+	option = {
+	name = lahmia0A #So let it be written, so let it be done!
+	set_character_flag = lahmia0
+	}
+
+	}
+
+	#lahmian vampire goes personally, instead of sending daughters
+	character_event = {
+	id = lahmia.1
+	title = LAHMIA
+	desc = lahmia1desc #You have decided to seduce this target personally. He will have no choice but to ultimate become your slave, and do all that you require of him...
+	picture = "GFX_vampiress1"
+
+	is_triggered_only = yes
+
+	option = {
+	name = lahmia1A #I'll need to pack... slaves! Ready my baggage-train!
+	wealth = -25
+	add_trait = on_lahmian_mission
+	FROM = { character_event = { id = lahmia.106 } }
+	}
+
+	}
+
+##Lahmian Targeted decision to seduce/subvert events#
+	character_event = {
+	id = lahmia.5
+	title = LAHMIA
+	desc = lahmia5desc #You have chosen this man to focus your efforts on. You will have to send one of your (unlanded) dynasty members to accomplish the task, only they are skilled enough to even attempt to seduce a powerful man like this.
+	picture = "GFX_evt_lovers"
+
+	is_triggered_only = yes
+
+	option = {
+	name = lahmia5A #I will send this one
+	wealth = -25
+	trigger = {
+		any_dynasty_member ={
+		is_female = yes
+		is_landed = no
+		trait = vampire_lahmian_visible
+		NOT = { trait = on_lahmian_mission }
+		}
+		}
+	random_dynasty_member ={
+		limit = {
+		is_female = yes
+		is_landed = no
+		trait = vampire_lahmian_visible
+		NOT = { trait = on_lahmian_mission }
+		}
+		character_event = { id = lahmia.6 }
+		}
+	}
+
+	option = {
+	name = lahmia5B #I will send an elite member of the Sisterhood
+	wealth = -25
+	trigger = {
+		any_child={
+		is_female = yes
+		trait = vampire_lahmian_visible
+		NOT = { trait = on_lahmian_mission }
+		has_minor_title = lahmian_elite_agent
+		}
+		}
+	random_child={
+		limit = {
+		is_female = yes
+		trait = vampire_lahmian_visible
+		NOT = { trait = on_lahmian_mission }
+		has_minor_title = lahmian_elite_agent
+		}
+		character_event = { id = lahmia.6 }
+		}
+	}
+	}
+
+	#daughter who is not currently on a mission gets her orders
+	character_event = {
+	id = lahmia.6
+	title = LAHMIA
+	desc = lahmia6desc #Your mother has instructed you to seduce a target, and bend him to the will of the Sisterhood. You must leave immediately.
+	picture = "GFX_vampiress1"
+
+	is_triggered_only = yes
+
+	option = {
+	name = lahmia6A #I shall pack my best outfits, perfumes, and jewels immediately, my Queen.
+	add_trait = on_lahmian_mission
+	FROMFROM = { character_event = { id = lahmia.104 } }
+	}
+
+	}
+
+	#bounce-back-event
+	character_event = {
+	id = lahmia.7
+	title = LAHMIA
+	desc = lahmia6desc #hidden
+	picture = "GFX_vampiress1"
+
+	is_triggered_only = yes
+
+	immediate = {
+	clr_character_flag = temp_lahmian_target
+	set_character_flag = lahmian_target
+	}
+
+	option = {
+	name = lahmia6A #hidden
+	FROMFROM = { character_event = { id = lahmia.5 } }
+	}
+
+	}
+
+	#SECOND bouncebackbounce-back-event
+	character_event = {
+	id = lahmia.104
+	title = LAHMIA
+	desc = lahmia6desc #hidden
+	picture = "GFX_vampiress1"
+
+	is_triggered_only = yes
+
+	immediate = {
+	set_character_flag = lahmian_target
+	}
+
+	option = {
+	name = lahmia6A #hidden
+	FROM = { character_event = { id = lahmia.8 days = 30 } }
+	}
+
+	}
+	#THIRD bouncebackbounce-back-event
+	character_event = {
+	id = lahmia.105
+	title = LAHMIA
+	desc = lahmia6desc #hidden
+	picture = "GFX_vampiress1"
+
+	is_triggered_only = yes
+
+	immediate = {
+	set_character_flag = lahmian_target
+	}
+
+	option = {
+	name = lahmia6A #hidden
+	FROMFROM = { character_event = { id = lahmia.1 } }
+	}
+
+	}
+
+	#FOURTH bouncebackbounce-back-event
+	character_event = {
+	id = lahmia.106
+	title = LAHMIA
+	desc = lahmia6desc #hidden
+	picture = "GFX_vampiress1"
+
+	is_triggered_only = yes
+
+	option = {
+	name = lahmia6A #hidden
+	FROM = { character_event = { id = lahmia.8  days = 30 } }
+	}
+
+	}
+	#lahmian on a mission gets the message that she has arrived at the foreign court
+	character_event = {
+	id = lahmia.8
+	title = LAHMIA
+	desc = lahmia8desc #You are in the lands of your target. Now... what shall we do...
+	picture = "GFX_vampiress1"
+
+	is_triggered_only = yes
+
+
+	option = {
+	name = lahmia8A #I will play the damsel in distress card...
+	trigger = {
+	FROM = { is_alive = yes }
+	age = 1
+	NOT = { has_character_flag = lahmia12failed }
+	NOT = { has_character_flag = damselindistress }
+	NOT = { has_character_flag = lahmianbanquet }
+	}
+	FROM = { character_event = { id = lahmia.10 days = 7 } }
+	set_character_flag = damselindistress
+	}
+
+	option = {
+	name = lahmia8B #I will host a lavish ball, as the rich new heiress in town
+	trigger = {
+	FROM = { is_alive = yes }
+	age = 1
+	NOT = { has_character_flag = lahmianbanquet }
+	NOT = { has_character_flag = damselindistress }
+	}
+	FROM = { character_event = { id = lahmia.15 days = 7 } }
+	set_character_flag = lahmianbanquet
+	}
+
+	option = {
+	name = lahmia8C #With his wife dead, he will need some comforting...
+	trigger = {
+	FROMFROM = { is_alive = yes }
+	age = 1
+	has_character_flag = killed_wife_success
+	NOT = { has_character_flag = lahmiancomfort }
+	}
+	FROMFROM = { character_event = { id = lahmia.30 days = 7 } }
+	set_character_flag = lahmiancomfort
+	}
+
+	option = {
+	name = lahmia8D #I will host a lavish ball, as the rich new heiress in town
+	trigger = {
+	FROMFROM = { is_alive = yes }
+	age = 1
+	NOT = { has_character_flag = lahmianbanquet }
+	has_character_flag = damselindistress
+	}
+	FROMFROM = { character_event = { id = lahmia.15 days = 7 } }
+	set_character_flag = lahmianbanquet
+	}
+
+	option = {
+	name = lahmiadeadtarget #Your target is dead. It's tme to go home.
+	trigger = {
+	FROM = { is_alive = no }
+	age = 1
+	NOT = { has_character_flag = lahmia12failed }
+	NOT = { has_character_flag = damselindistress }
+	NOT = { has_character_flag = lahmianbanquet }
+	}
+	remove_trait = on_lahmian_mission
+	clr_character_flag = damselindistress
+	clr_character_flag = lahmianbanquet
+	clr_character_flag = killed_wife_success
+	clr_character_flag = lahmiancomfort
+	clr_character_flag = lahmia12failed
+	clr_character_flag = return_home_lahmia
+	clr_character_flag = killed_wife_failure
+	set_variable = { which = "seduction_progress" value = 0 }
+	if = {
+	limit = {
+	NOT = { has_character_flag = lahmian_queen }
+	}
+	any_playable_ruler = {
+	limit = {
+	trait = lahmian_queen
+	}
+	character_event = { id = lahmia.101 } #101 informs the queen the target is dead and mission is over
+	}
+	}
+	}
+
+	}
+
+
+	#mother is told that the daughter has arrived safely at her destination
+	#character_event = {
+	#id = lahmia.9
+	#title = LAHMIA
+	#desc = lahmia9desc #Your daughter sends word - she has reached her destination safely, and will begin infiltrating the court as ordered and bend its ruler to your will.
+	#picture = "GFX_evt_shadow"
+	#
+	#is_triggered_only = yes
+    #
+	#
+	#option = {
+	#name = lahmia9A #Mmm... good.
+	#}
+	#
+	#}
+
+	#damsel in distress, our lahmian is being attacked by ruffians - the target gets the event##
+	character_event = {
+	id = lahmia.10
+	title = DAMSEL
+	desc = lahmia10desc #One morning while falconing, you hear a lady scream in the distance. She sounds like she is in serious trouble! You look around, and your companions are nowhere to be seen. What do you do?
+	picture = "GFX_evt_falconing"
+	hide_from = yes
+
+	is_triggered_only = yes
+
+
+	option = {
+	name = lahmia10A #I shall rescue the lady!
+	ai_chance = {
+			factor = 50
+
+			modifier = {
+				factor = 5
+				trait = brave
+			}
+			modifier = {
+				factor = 2
+				trait = lustful
+			}
+			modifier = {
+				factor = 2
+				trait = just
+			}
+		}
+	FROM = { long_character_event = { id = lahmia.11 } }
+	}
+
+
+	option = {
+	name = lahmia10B #If she's in trouble, I could be in danger. Ride for home at once!
+	ai_chance = {
+			factor = 50
+
+			modifier = {
+				factor = 10
+				trait = craven
+			}
+			modifier = {
+				factor = 2
+				trait = arbitrary
+			}
+			modifier = {
+				factor = 2
+				trait = cruel
+			}
+		}
+	FROM = { long_character_event = { id = lahmia.12 } }
+	}
+
+}
+
+	#damsel in distress, our lahmian fakes being attacked by thieves - the target helps##
+	long_character_event = {
+	id = lahmia.11
+	title = DAMSEL
+	desc = lahmia11desc #You hear your target is going falconing, and have had your handmaidens ensure that his companions would be.. distracted. Once you see him alone in the distance, you give the signal, and three hired ruffians pretend to attack you as you let out an ear-piercing scream of terror! Just as expected, your target comes riding full force with his sword drawn just when the ruffians throw you to the ground. Seeing him, they scatter in all directions, and he jumps off his horse, asking if you are unhurt.
+	picture = "GFX_evt_falconing"
+
+	is_triggered_only = yes
+
+	option = {
+	name = lahmia11A #Oh, my brave lord! You saved my life!
+	trigger = {
+	FROM = { is_alive = yes }
+	}
+	FROM = { character_event = { id = lahmia.13 } }
+	change_variable = { which = "seduction_progress" value = 1 }
+	}
+
+	option = {
+	name = lahmiadeadtarget #Your target is dead. It's tme to go home.
+	trigger = {
+	FROM = { is_alive = no }
+	}
+	remove_trait = on_lahmian_mission
+	clr_character_flag = damselindistress
+	clr_character_flag = lahmianbanquet
+	clr_character_flag = killed_wife_success
+	clr_character_flag = killed_wife_failure
+	clr_character_flag = lahmiancomfort
+	clr_character_flag = lahmia12failed
+	clr_character_flag = return_home_lahmia
+	set_variable = { which = "seduction_progress" value = 0 }
+	if = {
+	limit = {
+	NOT = { has_character_flag = lahmian_queen }
+	}
+	any_playable_ruler = {
+	limit = {
+	trait = lahmian_queen
+	}
+	character_event = { id = lahmia.101 } #101 informs the queen the target is dead and mission is over
+	}
+	}
+	}
+
+	}
+
+	#damsel in distress, our lahmian fakes being attacked by thieves - the target does not help##
+	long_character_event = {
+	id = lahmia.12
+	title = DAMSEL
+	desc = lahmia12desc #You hear your target is going falconing, and have had your handmaidens ensure that his companions would be.. distracted. Once you see him alone in the distance, you give the signal, and three hired ruffians pretend to attack you as you let out an ear-piercing scream of terror! You see your intended staring, hesitating, even as the ruffians throw you to the ground and act like they are about to rape you. Then the coward turns and rides away at full speed! Useless, weak, and thrice-cursed mortal fool!
+
+	picture = "GFX_evt_falconing"
+
+	is_triggered_only = yes
+
+	option = {
+	name = lahmia12A #*hiss* I'll need time to come up with a new plan...
+	trigger = {
+	FROM = { is_alive = yes }
+	}
+	character_event = { id = lahmia.8 days = 90 }
+	set_character_flag = lahmia12failed
+	change_variable = { which = "seduction_progress" value = -1 }
+	}
+
+	option = {
+	name = lahmiadeadtarget #Your target is dead. It's tme to go home.
+	trigger = {
+	FROM = { is_alive = no }
+	}
+	remove_trait = on_lahmian_mission
+	clr_character_flag = damselindistress
+	clr_character_flag = lahmianbanquet
+	clr_character_flag = killed_wife_success
+	clr_character_flag = killed_wife_failure
+	clr_character_flag = lahmiancomfort
+	clr_character_flag = lahmia12failed
+	clr_character_flag = return_home_lahmia
+	set_variable = { which = "seduction_progress" value = 0 }
+	if = {
+	limit = {
+	NOT = { has_character_flag = lahmian_queen }
+	}
+	any_playable_ruler = {
+	limit = {
+	trait = lahmian_queen
+	}
+	character_event = { id = lahmia.101 } #101 informs the queen the target is dead and mission is over
+	}
+	}
+	}
+
+	}
+
+	#damsel in distress, our lahmian fakes being attacked by thieves - the target does not help##
+	character_event = {
+	id = lahmia.13
+	title = DAMSEL
+	desc = lahmia13desc #As you rush towards them with your sword drawn, the ruffians quickly scatter. The lady is beautiful, and judging from her torn clothes and jewels, obviously very rich. She thanks you profusely, and you escort her back to the city. Upon arrival she takes her leave, but promises that she will repay you for your heroism.
+	hide_from = yes
+
+	picture = "GFX_evt_falconing"
+
+	is_triggered_only = yes
+
+	option = {
+	name = lahmia13A #What a stunning beauty. I'm a hero for saving her!
+	prestige = 25
+	FROM = { character_event = { id = lahmia.14 days = 1 } }
+	set_character_flag = saved_lahmian
+	}
+
+	}
+
+
+	#damsel in distress, our lahmian fakes being attacked by thieves - the target does not help##
+	character_event = {
+	id = lahmia.14
+	title = DAMSEL
+	desc = lahmia14desc #You play the part of the noble damsel in distress perfectly, allowing him to see himself as your saviour and protector as he escorts you back to the city. Upon arriving at the market, you take your leave, but promise to reward him for his heroism.
+
+	picture = "GFX_evt_market"
+
+	is_triggered_only = yes
+
+	option = {
+	trigger = {
+	FROM = { is_alive = yes }
+	}
+	name = lahmia14A #Now I will host a grand gala...
+	FROM = { character_event = { id = lahmia.15 days = 30 } }
+	set_character_flag = lahmianbanquet
+	}
+
+	option = {
+	name = lahmia14B #I should get rid of his wife first...
+	trigger = {
+	FROM = { is_married = yes }
+	FROM = { is_alive = yes }
+	OR = {
+	ai = no
+	OR = {
+	trait = cruel
+	trait = impaler
+	}
+	}
+	}
+	FROM = { character_event = { id = lahmia.20 days = 30 } }
+	}
+
+	option = {
+	name = lahmiadeadtarget #Your target is dead. It's tme to go home.
+	trigger = {
+	FROM = { is_alive = no }
+	}
+	remove_trait = on_lahmian_mission
+	clr_character_flag = damselindistress
+	clr_character_flag = lahmianbanquet
+	clr_character_flag = killed_wife_success
+	clr_character_flag = killed_wife_failure
+	clr_character_flag = lahmiancomfort
+	clr_character_flag = lahmia12failed
+	clr_character_flag = return_home_lahmia
+	set_variable = { which = "seduction_progress" value = 0 }
+	if = {
+	limit = {
+	NOT = { has_character_flag = lahmian_queen }
+	}
+	any_playable_ruler = {
+	limit = {
+	trait = lahmian_queen
+	}
+	character_event = { id = lahmia.101 } #101 informs the queen the target is dead and mission is over
+	}
+	}
+	}
+
+	}
+
+	#banquet event chain, target is invited
+	character_event = {
+	id = lahmia.15
+	title = BANQUET
+	desc = lahmia15desc #Word around the city is that a rich heiress is hosting a magnificent ball, and of course your invitation arrived just this morning in gold-stamped letters. Rumors says that she is as beautiful as she is rich. Do you want to attend?
+	picture = "GFX_evt_cultist"
+	hide_from = yes
+
+	is_triggered_only = yes
+
+	option = {
+	name = lahmia15A #Why yes, of course! Next Friday? Certainly.
+	trigger = {
+	age = 1
+	NOT = { has_character_flag = saved_lahmian }
+	}
+ai_chance = {
+      factor = 50
+
+      modifier = {
+         factor = 2.0
+         trait = gregarious
+      }
+      modifier = {
+         factor = 2.0
+         trait = lustful
+      }
+      modifier = {
+         factor = 2.0
+         trait = hedonist
+      }
+      modifier = {
+         factor = 2.0
+         trait = ambitious
+      }
+      modifier = {
+         factor = 2.0
+         FROM = { intrigue = 10 }
+      }
+      modifier = {
+         factor = 2.0
+         FROM = { intrigue = 15 }
+      }
+      modifier = {
+         factor = 2.0
+         FROM = { intrigue = 20 }
+      }
+      modifier = {
+         factor = 2.0
+         FROM = { intrigue = 25 }
+      }
+      modifier = {
+         factor = 1.5
+         FROM = { trait = fair }
+      }
+      modifier = {
+         factor = 2.0
+         FROM = { trait = pretty }
+      }
+      modifier = {
+         factor = 3.0
+         FROM = { trait = beautiful }
+      }
+}
+	FROM = { long_character_event = { id = lahmia.16 days = 7 } }
+	}
+
+	option = {
+	name = lahmia15B #Oh, it's the lady I saved while falconing! Of course I'll attend.
+	trigger = {
+	age = 1
+	has_character_flag = saved_lahmian
+	}
+ai_chance = {
+      factor = 50
+
+      modifier = {
+         factor = 2.0
+         trait = gregarious
+      }
+      modifier = {
+         factor = 2.0
+         trait = lustful
+      }
+      modifier = {
+         factor = 2.0
+         trait = hedonist
+      }
+      modifier = {
+         factor = 2.0
+         trait = ambitious
+      }
+      modifier = {
+         factor = 2.0
+         FROM = { intrigue = 10 }
+      }
+      modifier = {
+         factor = 2.0
+         FROM = { intrigue = 15 }
+      }
+      modifier = {
+         factor = 2.0
+         FROM = { intrigue = 20 }
+      }
+      modifier = {
+         factor = 2.0
+         FROM = { intrigue = 25 }
+      }
+      modifier = {
+         factor = 1.5
+         FROM = { trait = fair }
+      }
+      modifier = {
+         factor = 2.0
+         FROM = { trait = pretty }
+      }
+      modifier = {
+         factor = 3.0
+         FROM = { trait = beautiful }
+      }
+}
+	FROM = { long_character_event = { id = lahmia.16 days = 7 } }
+	}
+
+	option = {
+	name = lahmia15C #No, I have no interest in balls or heiresses
+ai_chance = {
+      factor = 50
+
+      modifier = {
+         factor = 2.0
+         trait = shy
+      }
+      modifier = {
+         factor = 2.0
+         trait = chaste
+      }
+      modifier = {
+         factor = 2.0
+         is_married = yes
+      }
+      modifier = {
+         factor = 8.0
+         trait = celibate
+      }
+      modifier = {
+         factor = 10.0
+         trait = homosexual
+      }
+      modifier = {
+         factor = 1.5
+         FROM = { trait = plain }
+      }
+      modifier = {
+         factor = 2.0
+         FROM = { trait = ugly }
+      }
+      modifier = {
+         factor = 3.0
+         FROM = { trait = unsightly }
+      }
+}
+	FROM = { character_event = { id = lahmia.33 days = 7 } }
+	}
+	}
+
+	#banquet event chain - banquet start, lahmia point of view
+	long_character_event = {
+	id = lahmia.16
+	title = BANQUET
+	desc = lahmia16desc #Tonight is the night of the ball you are hosting. Everything has been prepared to exquisite detail, and you are the center of attention and envy in the room. Finally, your prize guest arrives and the evening proceeds down to the minutest detail of your desires. The music is playing, the nobles are dancing, and the wine flows. You dance with your guest of honor, and work your arts of seduction on him subtly. As the evening draws to a close, it is time to make your move...
+	picture = "GFX_evt_cultist"
+
+	is_triggered_only = yes
+
+	option = {
+	trigger = {
+	FROM = { is_alive = yes }
+	}
+	name = lahmia16A #Whisper in his ear and suggest he stay the night.
+	FROM = { long_character_event = { id = lahmia.17 } }
+	}
+
+	option = {
+	name = lahmia16B #Poison his wife, his grief will make him vulnerable.
+	trigger = {
+	FROM = { is_married = yes }
+	FROM = { is_alive = yes }
+	}
+	FROM = { character_event = { id = lahmia.25 } }
+	}
+
+	option = {
+	name = lahmiadeadtarget #Your target is dead. It's tme to go home.
+	trigger = {
+	FROM = { is_alive = no }
+	}
+	remove_trait = on_lahmian_mission
+	clr_character_flag = damselindistress
+	clr_character_flag = lahmianbanquet
+	clr_character_flag = killed_wife_success
+	clr_character_flag = killed_wife_failure
+	clr_character_flag = lahmiancomfort
+	clr_character_flag = lahmia12failed
+	clr_character_flag = return_home_lahmia
+	set_variable = { which = "seduction_progress" value = 0 }
+	if = {
+	limit = {
+	NOT = { has_character_flag = lahmian_queen }
+	}
+	any_playable_ruler = {
+	limit = {
+	trait = lahmian_queen
+	}
+	character_event = { id = lahmia.101 } #101 informs the queen the target is dead and mission is over
+	}
+	}
+	}
+
+	}
+
+	#banquet event chain - banquet start, target point of view
+	long_character_event = {
+	id = lahmia.17
+	title = BANQUET
+	desc = lahmia17desc #Tonight is the night of the grand gala. You arrive to a splendid mansion and are greeted by the beautiful - and obviously fabulously wealthy - heiress. As the wine flows and the music plays, you find your eyes inexplicably drawn towards her, and you often find her smiling seductively back at you from across the room. As the evening draws to a close, the last dance is called, and she glides over and takes you to the floor. After a flawlessly executed dance, she whispers hotly in your ear 'Care to stay the night, my lord?'
+	picture = "GFX_evt_cultist"
+	hide_from = yes
+
+	is_triggered_only = yes
+
+	option = {
+	name = lahmia17A #*whisper back* I'll return when the guests have left...
+ai_chance = {
+      factor = 50
+
+      modifier = {
+         factor = 2.0
+         trait = gregarious
+      }
+      modifier = {
+         factor = 2.0
+         trait = lustful
+      }
+      modifier = {
+         factor = 2.0
+         trait = hedonist
+      }
+      modifier = {
+         factor = 2.0
+         trait = ambitious
+      }
+      modifier = {
+         factor = 2.0
+         FROM = { intrigue = 10 }
+      }
+      modifier = {
+         factor = 2.0
+         FROM = { intrigue = 15 }
+      }
+      modifier = {
+         factor = 2.0
+         FROM = { intrigue = 20 }
+      }
+      modifier = {
+         factor = 2.0
+         FROM = { intrigue = 25 }
+      }
+      modifier = {
+         factor = 1.5
+         FROM = { trait = fair }
+      }
+      modifier = {
+         factor = 2.0
+         FROM = { trait = pretty }
+      }
+      modifier = {
+         factor = 3.0
+         FROM = { trait = beautiful }
+      }
+}
+	FROM = { long_character_event = { id = lahmia.18 } }
+	}
+
+	#option = {
+	#name = lahmia17B #But.. I'm married! I can't!
+	#trigger = {
+	#is_married = yes
+	#}
+	#FROM = { character_event = { id = lahmia.XXX } }
+	#}
+
+	option = {
+	name = lahmia17C #No, that would not be proper, my lady. Good night.
+ai_chance = {
+      factor = 50
+
+      modifier = {
+         factor = 2.0
+         trait = shy
+      }
+      modifier = {
+         factor = 2.0
+         trait = chaste
+      }
+      modifier = {
+         factor = 2.0
+         is_married = yes
+      }
+      modifier = {
+         factor = 8.0
+         trait = celibate
+      }
+      modifier = {
+         factor = 10.0
+         trait = homosexual
+      }
+      modifier = {
+         factor = 1.5
+         FROM = { trait = plain }
+      }
+      modifier = {
+         factor = 2.0
+         FROM = { trait = ugly }
+      }
+      modifier = {
+         factor = 3.0
+         FROM = { trait = unsightly }
+      }
+}
+	FROM = { character_event = { id = lahmia.34 days = 1 } }
+	}
+
+
+	}
+
+	#banquet event chain - target stays the night, lahmia point of view
+	long_character_event = {
+	id = lahmia.18
+	picture = "GFX_vampiress1"
+	title = LAHMIA_LOVERS
+
+	desc = {
+		text = lahmia18descA #You seduce your target into a night of wild passion, and as dawn is about to break, you know that for the moment at least - he is under your spell. While he remains so, you can use your influence once a year to get him to send you expensive gifts, or even troops on some pretext that your distant family lands are under threat from orcs or even vampires. Should you leave him to return to your own lands, however, your hold over him will be lost.
+		trigger = {
+			trait = lahmian_queen
+		}
+	}
+	desc = {
+		text = lahmia18descB #You seduce your target into a night of wild passion, and as dawn is about to break, you know that for the moment at least - he is under your spell. While he remains so, you can use your influence once a year to get him to send you expensive gifts, or even troops on some pretext that your distant family lands are under threat from orcs or even vampires. You will then pass these on to your queen, to further the cause of restoring ancient Lahmia to the sisterhood. Should you leave him to return to your own lands, however, your hold over him will be lost.
+		trigger = {
+			NOT = { trait = lahmian_queen }
+		}
+	}
+
+	is_triggered_only = yes
+
+	option = {
+	name = lahmia18A #I knew he would not resist me.
+	trigger = {
+	FROM = { is_alive = yes }
+	}
+	ROOT = {long_character_event = { id = lahmia.50 days = 365 } } ##lahmia.50 is the yearly maintenance event where you can ask for favors from your lovers
+	change_variable = { which = "seduction_progress" value = 5 }
+	if = {
+	limit = {
+	age = 1
+	NOT = { has_character_flag = killed_wife_success }
+	}
+	FROM = { character_event = { id = lahmia.19 } }
+	}
+	}
+
+	option = {
+	name = lahmiadeadtarget #Your target is dead. It's tme to go home.
+	trigger = {
+	FROM = { is_alive = no }
+	}
+	remove_trait = on_lahmian_mission
+	clr_character_flag = damselindistress
+	clr_character_flag = lahmianbanquet
+	clr_character_flag = killed_wife_success
+	clr_character_flag = killed_wife_failure
+	clr_character_flag = lahmiancomfort
+	clr_character_flag = lahmia12failed
+	clr_character_flag = return_home_lahmia
+	set_variable = { which = "seduction_progress" value = 0 }
+	if = {
+	limit = {
+	NOT = { has_character_flag = lahmian_queen }
+	}
+	any_playable_ruler = {
+	limit = {
+	trait = lahmian_queen
+	}
+	character_event = { id = lahmia.101 } #101 informs the queen the target is dead and mission is over
+	}
+	}
+	}
+
+	}
+
+	#banquet event chain - target stays the night, target point of view
+	character_event = {
+	id = lahmia.19
+	title = BANQUET
+	desc = lahmia19desc #You have spent a night of wild passion with this beautiful and mysterious new heiress, and you are certain that you'll be seeing more of her in the months and years to come. You have scratch and bite marks all over your body, and though it hurts to get dressed, you leave with a smile on your face.
+	picture = "GFX_vampiress1"
+	hide_from = yes
+
+	is_triggered_only = yes
+
+	option = {
+	name = lahmia19A #Until next time, mysterious lady.
+	}
+
+	}
+
+	##Kill wife of target, after the falconing incident##
+	character_event = {
+	id = lahmia.20
+	title = BANQUET
+	desc = lahmia19desc #hidden, this event determines if his wife dies or if the lahmia has to flee town and maybe get killed
+	picture = "GFX_vampiress1"
+	hide_window = yes
+
+	is_triggered_only = yes
+
+	option = {
+	name = lahmia19A #hidden
+	if = {
+	limit = {
+	FROM = { intrigue = 25 }
+	}
+	random_list = {
+	99 = { character_event = { id = lahmia.21 }	} #success
+	1 = { character_event = { id = lahmia.23 } } #failure
+	}
+	}
+	if = {
+	limit = {
+	FROM = { intrigue = 20 }
+	FROM = { NOT = { intrigue = 25 } }
+	}
+	random_list = {
+	85 = { character_event = { id = lahmia.21 }	} #success
+	15 = { character_event = { id = lahmia.23 } } #failure
+	}
+	}
+	if = {
+	limit = {
+	FROM = { intrigue = 15 }
+	FROM = { NOT = { intrigue = 20 } }
+	}
+	random_list = {
+	75 = { character_event = { id = lahmia.21 }	} #success
+	25 = { character_event = { id = lahmia.23 } } #failure
+	}
+	}
+	if = {
+	limit = {
+	FROM = { intrigue = 10 }
+	FROM = { NOT = { intrigue = 15 } }
+	}
+	random_list = {
+	50 = { character_event = { id = lahmia.21 }	} #success
+	50 = { character_event = { id = lahmia.23 } } #failure
+	}
+	}
+	if = {
+	limit = {
+	FROM = { intrigue = 1 }
+	FROM = { NOT = { intrigue = 10 } }
+	}
+	random_list = {
+	30 = { character_event = { id = lahmia.21 }	} #success
+	70 = { character_event = { id = lahmia.23 } } #failure
+	}
+	}
+	}
+
+	}
+
+	##Kill wife of target, after the falconing incident, success, target is informed##
+	character_event = {
+	id = lahmia.21
+	title = GRIEF
+	desc = lahmia21desc #Cruel fate! Your wife suddenly took ill, and died screaming in the night. It happened so soon... but the doctors could find no trace of poison, and who would have any motive?
+	picture = "GFX_evt_bad_news_female"
+	hide_from = yes
+
+	is_triggered_only = yes
+
+	option = {
+	name = lahmia21A #Curses! Why gods, why?!
+	spouse = {
+		if = {
+ limit = {
+ is_invincible_trigger = yes
+ }
+
+			antideath_effect = yes
+			break = yes
+}
+	death = { death_reason = death_murder_unknown }
+	}
+	FROMFROM = { character_event = { id = lahmia.22 } }
+	}
+
+	option = {
+	name = lahmia21B #These are perilous times...
+	spouse = {
+		if = {
+ limit = {
+ is_invincible_trigger = yes
+ }
+
+			antideath_effect = yes
+			break = yes
+}
+	death = { death_reason = death_murder_unknown }
+	}
+	FROMFROM = { character_event = { id = lahmia.22 } }
+	}
+
+	}
+
+	##Kill wife of target, after the falconing incident, success, vampire is informed##
+	character_event = {
+	id = lahmia.22
+	title = LAHMIA_SEDUCTION
+	desc = lahmia22desc #Hah! The targets wife died 'suddenly and tragically'... what a shame... and from my spies in the court, no one knows why. Those servant boys I seduced did very well indeed. That's one obstacle removed. Now... to proceed with the plan...
+	picture = "GFX_vampiress1"
+	hide_from = yes
+
+	is_triggered_only = yes
+
+	option = {
+	trigger = {
+	FROM = { is_alive = yes }
+	}
+	name = lahmia22A #Yes, what shall be the next step?
+	set_character_flag = killed_wife_success
+	character_event = { id = lahmia.8 days = 7 }
+	}
+
+	option = {
+	name = lahmiadeadtarget #Your target is dead. It's tme to go home.
+	trigger = {
+	FROM = { is_alive = no }
+	}
+	remove_trait = on_lahmian_mission
+	clr_character_flag = damselindistress
+	clr_character_flag = lahmianbanquet
+	clr_character_flag = killed_wife_success
+	clr_character_flag = killed_wife_failure
+	clr_character_flag = lahmiancomfort
+	clr_character_flag = lahmia12failed
+	clr_character_flag = return_home_lahmia
+	set_variable = { which = "seduction_progress" value = 0 }
+	if = {
+	limit = {
+	NOT = { has_character_flag = lahmian_queen }
+	}
+	any_playable_ruler = {
+	limit = {
+	trait = lahmian_queen
+	}
+	character_event = { id = lahmia.101 } #101 informs the queen the target is dead and mission is over
+	}
+	}
+	}
+
+	}
+
+	##Kill wife of target, after the falconing incident, failure, target is informed##
+	character_event = {
+	id = lahmia.23
+	title = GRIEF
+	desc = lahmia23desc #A plot to poison your wife has been revealed! When put to the question, the servants who were caught with the poison revealed everything - a beautiful rich heiress seduced them to do the dark deed...
+	picture = "GFX_evt_bad_news_female"
+	hide_from = yes
+
+	is_triggered_only = yes
+
+	option = {
+	name = lahmia23A #I want this 'heiress' seized and executed!
+	spouse = { add_trait = stressed }
+	FROMFROM = { character_event = { id = lahmia.24 } }
+	}
+
+	}
+
+	##Kill wife of target, after the falconing incident, failure, vampire is informed##
+	character_event = {
+	id = lahmia.24
+	title = LAHMIA_SEDUCTION
+	desc = lahmia24desc #Damnations! Those fool servant boys you seduced got themselves caught trying to poison your targets wife, and your sources in the court say that they spoke your name. This cat and mouse game is over. Time to flee.
+	picture = "GFX_vampiress1"
+	hide_from = yes
+
+	is_triggered_only = yes
+
+	option = {
+	name = lahmia24A #I only hope my Queen will forgive my failure.
+	trigger = { NOT = { trait = lahmian_queen } }
+	remove_trait = on_lahmian_mission
+	clr_character_flag = damselindistress
+	clr_character_flag = lahmianbanquet
+	clr_character_flag = killed_wife_success
+	clr_character_flag = killed_wife_failure
+	clr_character_flag = lahmiancomfort
+	clr_character_flag = lahmia12failed
+	clr_character_flag = return_home_lahmia
+	set_variable = { which = "seduction_progress" value = 0 }
+	any_playable_ruler = {
+	limit = { trait = lahmian_queen }
+	character_event = { id = lahmia.100 } ##100 is the failure event that the queen gets
+	}
+	}
+
+	option = {
+	name = lahmia24B #I can't believe I failed...
+	trigger = { trait = lahmian_queen }
+	remove_trait = on_lahmian_mission
+	clr_character_flag = damselindistress
+	clr_character_flag = lahmianbanquet
+	clr_character_flag = killed_wife_success
+	clr_character_flag = lahmiancomfort
+	clr_character_flag = lahmia12failed
+	clr_character_flag = return_home_lahmia
+	set_variable = { which = "seduction_progress" value = 0 }
+	}
+
+	}
+
+	###KILL WIFE OF TARGET DURING THE FEAST
+character_event = {
+	id = lahmia.25
+	title = BANQUET
+	desc = lahmia19desc #hidden, this event determines if his wife dies or if the lahmia has to flee town and maybe get killed
+	picture = "GFX_vampiress1"
+	hide_window = yes
+
+	is_triggered_only = yes
+
+	option = {
+	name = lahmia19A #hidden
+	if = {
+	limit = {
+	FROM = { intrigue = 25 }
+	}
+	random_list = {
+	99 = { character_event = { id = lahmia.26 }	} #success
+	1 = { character_event = { id = lahmia.28 } } #failure
+	}
+	}
+	if = {
+	limit = {
+	FROM = { intrigue = 20 }
+	FROM = { NOT = { intrigue = 25 } }
+	}
+	random_list = {
+	85 = { character_event = { id = lahmia.26 }	} #success
+	15 = { character_event = { id = lahmia.28 } } #failure
+	}
+	}
+	if = {
+	limit = {
+	FROM = { intrigue = 15 }
+	FROM = { NOT = { intrigue = 20 } }
+	}
+	random_list = {
+	75 = { character_event = { id = lahmia.26 }	} #success
+	25 = { character_event = { id = lahmia.28 } } #failure
+	}
+	}
+	if = {
+	limit = {
+	FROM = { intrigue = 10 }
+	FROM = { NOT = { intrigue = 15 } }
+	}
+	random_list = {
+	50 = { character_event = { id = lahmia.26 }	} #success
+	50 = { character_event = { id = lahmia.28 } } #failure
+	}
+	}
+	if = {
+	limit = {
+	FROM = { intrigue = 1 }
+	FROM = { NOT = { intrigue = 10 } }
+	}
+	random_list = {
+	30 = { character_event = { id = lahmia.26 }	} #success
+	70 = { character_event = { id = lahmia.28 } } #failure
+	}
+	}
+	}
+
+	}
+
+	##Kill wife of target, after the feast incident, success, target is informed##
+	character_event = {
+	id = lahmia.26
+	title = GRIEF
+	desc = lahmia26desc #Cruel fate! As you wake up the next day, your wife lies dead next to you. It happened so soon and so quietly... but the doctors could find no trace of poison, and who would have any motive?
+	picture = "GFX_evt_bad_news_female"
+	hide_from = yes
+
+	is_triggered_only = yes
+
+	option = {
+	name = lahmia26A #Curses! Why gods, why?!
+	spouse = {
+		if = {
+ limit = {
+ is_invincible_trigger = yes
+ }
+
+			antideath_effect = yes
+			break = yes
+}
+	death = { death_reason = death_murder_unknown }
+	}
+	FROMFROM = { character_event = { id = lahmia.27 } }
+	}
+
+	option = {
+	name = lahmia26B #These are perilous times...
+	spouse = {
+		if = {
+ limit = {
+ is_invincible_trigger = yes
+ }
+
+			antideath_effect = yes
+			break = yes
+}
+	death = { death_reason = death_murder_unknown }
+	}
+	FROMFROM = { character_event = { id = lahmia.27 days = 1 } }
+	}
+
+	}
+
+	##Kill wife of target, after the feast incident, success, vampire is informed##
+	character_event = {
+	id = lahmia.27
+	title = LAHMIA_SEDUCTION
+	desc = lahmia27desc #From one of your rings, you manage to dip some poison into the target's wifes cup, just as the final toast is made. From reports, she died quietly in her sleep in the night, and no one knows why. That's one obstacle removed. Now... to proceed with the plan...
+	picture = "GFX_vampiress1"
+	hide_from = yes
+
+	is_triggered_only = yes
+
+	option = {
+	name = lahmia27A #Yes, what shall be the next step?
+	trigger = {
+	FROM = { is_alive = yes }
+	}
+	set_character_flag = killed_wife_success
+	character_event = { id = lahmia.8 days = 7 }
+	}
+
+	option = {
+	name = lahmiadeadtarget #Your target is dead. It's tme to go home.
+	trigger = {
+	FROM = { is_alive = no }
+	}
+	remove_trait = on_lahmian_mission
+	clr_character_flag = damselindistress
+	clr_character_flag = lahmianbanquet
+	clr_character_flag = killed_wife_success
+	clr_character_flag = killed_wife_failure
+	clr_character_flag = lahmiancomfort
+	clr_character_flag = lahmia12failed
+	clr_character_flag = return_home_lahmia
+	set_variable = { which = "seduction_progress" value = 0 }
+	if = {
+	limit = {
+	NOT = { has_character_flag = lahmian_queen }
+	}
+	any_playable_ruler = {
+	limit = {
+	trait = lahmian_queen
+	}
+	character_event = { id = lahmia.101 } #101 informs the queen the target is dead and mission is over
+	}
+	}
+	}
+
+	}
+
+	##Kill wife of target, after the feast incident, failure, target is informed##
+	character_event = {
+	id = lahmia.28
+	title = GRIEF
+	desc = lahmia28desc #Your wife has been poisoned, but due to the quick actions of a priest she was saved in time! It must have happened during the feast...
+	picture = "GFX_evt_bad_news_female"
+	hide_from = yes
+
+	is_triggered_only = yes
+
+	option = {
+	name = lahmia28A #I want all who attended questioned immediately!
+	spouse = { add_trait = stressed }
+	FROMFROM = { character_event = { id = lahmia.29 } }
+	}
+
+	}
+
+	##Kill wife of target, after the feast incident, failure, vampire is informed##
+	character_event = {
+	id = lahmia.29
+	title = LAHMIA_SEDUCTION
+	desc = lahmia29desc #Damnations! From your sources inside the court, you learn that the place is in an uproar. Her life was saved by a priest, but they are going to conduct a thorough investigation of everyone who attend the feast. As a vampire, you cannot pass such close examination... This cat and mouse game is over. Time to flee.
+	picture = "GFX_vampiress1"
+	hide_from = yes
+
+	is_triggered_only = yes
+
+	option = {
+	name = lahmia29A #I only hope my Queen will forgive my failure.
+	trigger = { NOT = { trait = lahmian_queen } }
+	set_character_flag = killed_wife_failure
+	remove_trait = on_lahmian_mission
+	clr_character_flag = damselindistress
+	clr_character_flag = lahmianbanquet
+	clr_character_flag = killed_wife_success
+	clr_character_flag = killed_wife_failure
+	clr_character_flag = lahmiancomfort
+	clr_character_flag = lahmia12failed
+	clr_character_flag = return_home_lahmia
+	set_variable = { which = "seduction_progress" value = 0 }
+	any_playable_ruler = {
+	limit = { trait = lahmian_queen }
+	character_event = { id = lahmia.100 } ##100 is the failure event that the queen gets
+	}
+	}
+
+	option = {
+	name = lahmia29B #I can't believe I failed...
+	trigger = { trait = lahmian_queen }
+	set_character_flag = killed_wife_failure
+	remove_trait = on_lahmian_mission
+	clr_character_flag = damselindistress
+	clr_character_flag = lahmianbanquet
+	clr_character_flag = killed_wife_success
+	clr_character_flag = killed_wife_failure
+	clr_character_flag = lahmiancomfort
+	clr_character_flag = lahmia12failed
+	clr_character_flag = return_home_lahmia
+	set_variable = { which = "seduction_progress" value = 0 }
+	}
+
+	}
+
+	###NOW THE SEDUCTION EVENT AFTER THE WIFE HAS BEEN KILLED##
+	##lahmia seduces man after loss of his wife, target point of view
+	character_event = {
+	id = lahmia.30
+	title = GRIEF
+	desc = lahmia30desc #The shock of your wife's death still haunts you, but your new lady acquaintance has been a great help and comfort. You find yourself thinking about her all the time. Perhaps, it would not be wrong to let this go a little further?
+	picture = "GFX_evt_illness"
+	hide_from = yes
+
+	is_triggered_only = yes
+
+	option = {
+	name = lahmia30A #Yes, surely it was meant to be!
+ai_chance = {
+      factor = 50
+
+      modifier = {
+         factor = 2.0
+         trait = gregarious
+      }
+      modifier = {
+         factor = 2.0
+         trait = lustful
+      }
+      modifier = {
+         factor = 2.0
+         trait = hedonist
+      }
+      modifier = {
+         factor = 2.0
+         trait = ambitious
+      }
+      modifier = {
+         factor = 2.0
+         FROM = { intrigue = 10 }
+      }
+      modifier = {
+         factor = 2.0
+         FROM = { intrigue = 15 }
+      }
+      modifier = {
+         factor = 2.0
+         FROM = { intrigue = 20 }
+      }
+      modifier = {
+         factor = 2.0
+         FROM = { intrigue = 25 }
+      }
+      modifier = {
+         factor = 1.5
+         FROM = { trait = fair }
+      }
+      modifier = {
+         factor = 2.0
+         FROM = { trait = pretty }
+      }
+      modifier = {
+         factor = 3.0
+         FROM = { trait = beautiful }
+      }
+}
+	FROM = { character_event = { id = lahmia.31 } }
+	}
+
+	option = {
+	name = lahmia30B #No. There is something 'off' about her...
+ai_chance = {
+      factor = 50
+
+      modifier = {
+         factor = 2.0
+         trait = shy
+      }
+      modifier = {
+         factor = 2.0
+         trait = chaste
+      }
+      modifier = {
+         factor = 2.0
+         is_married = yes
+      }
+      modifier = {
+         factor = 8.0
+         trait = celibate
+      }
+      modifier = {
+         factor = 10.0
+         trait = homosexual
+      }
+      modifier = {
+         factor = 1.5
+         FROM = { trait = plain }
+      }
+      modifier = {
+         factor = 2.0
+         FROM = { trait = ugly }
+      }
+      modifier = {
+         factor = 3.0
+         FROM = { trait = unsightly }
+      }
+}
+	FROM = { character_event = { id = lahmia.32 } }
+	}
+	}
+
+	##lahmia seduces man after loss of his wife, success, lahmian point of view
+	character_event = {
+	id = lahmia.31
+	title = LAHMIA_SEDUCTION
+	desc = lahmia31desc #You have played the role of a trusted friend to your target since his wife's death, and one night after a lot of wine he moves in to kiss you. Hah - your skills of seduction are as strong as ever, he never had a chance...
+	picture = "GFX_vampiress1"
+
+	is_triggered_only = yes
+
+	option = {
+	name = lahmia31A #All men are weak, if you only know which buttons to push.
+	trigger = {
+	FROM = { is_alive = yes }
+	}
+	FROM = { character_event = { id = lahmia.19 } }
+	long_character_event = { id = lahmia.18 days = 1 }
+	}
+
+	option = {
+	name = lahmiadeadtarget #Your target is dead. It's tme to go home.
+	trigger = {
+	FROM = { is_alive = no }
+	}
+	remove_trait = on_lahmian_mission
+	clr_character_flag = damselindistress
+	clr_character_flag = lahmianbanquet
+	clr_character_flag = killed_wife_success
+	clr_character_flag = killed_wife_failure
+	clr_character_flag = lahmiancomfort
+	clr_character_flag = lahmia12failed
+	clr_character_flag = return_home_lahmia
+	set_variable = { which = "seduction_progress" value = 0 }
+	if = {
+	limit = {
+	NOT = { has_character_flag = lahmian_queen }
+	}
+	any_playable_ruler = {
+	limit = {
+	trait = lahmian_queen
+	}
+	character_event = { id = lahmia.101 } #101 informs the queen the target is dead and mission is over
+	}
+	}
+	}
+
+	}
+
+	##NOW THE BREAK CHAIN FAILURE EVENTS##
+	##lahmia seduces man after loss of his wife, failure, lahmian point of view
+	character_event = {
+	id = lahmia.32
+	title = LAHMIA_SEDUCTION
+	desc = lahmia32desc #Despite trying your best to seduce your target, it seems you have failed! He is no longer answering your letters, and the guards at the gates will not admit you to his presence any more. It seems you must return home and give up on this chase...
+	picture = "GFX_vampiress1"
+	hide_from = yes
+
+	is_triggered_only = yes
+
+	option = {
+	name = lahmia32A #Curses!
+	remove_trait = on_lahmian_mission
+	clr_character_flag = damselindistress
+	clr_character_flag = lahmianbanquet
+	clr_character_flag = killed_wife_success
+	clr_character_flag = killed_wife_failure
+	clr_character_flag = lahmiancomfort
+	clr_character_flag = lahmia12failed
+	clr_character_flag = return_home_lahmia
+	set_variable = { which = "seduction_progress" value = 0 }
+	if = {
+	limit = {
+	NOT = { trait = lahmian_queen }
+	}
+	any_playable_ruler = {
+	limit = { trait = lahmian_queen }
+	character_event = { id = lahmia.100 } ##100 is the failure event that the queen gets
+	}
+	}
+	}
+
+	}
+
+	##target says he has no interest in balls or heiresses, chase is over
+	character_event = {
+	id = lahmia.33
+	title = LAHMIA_SEDUCTION
+	desc = lahmia33desc #Your target refuses to take the bait, and has sent word that he will not attend your ball. Your attempts to get in further contact with him have all failed. It seems you must give up on this chase... it's time to return home.
+	picture = "GFX_vampiress1"
+	hide_from = yes
+
+	is_triggered_only = yes
+
+	option = {
+	name = lahmia33A #Curses!
+	remove_trait = on_lahmian_mission
+	clr_character_flag = damselindistress
+	clr_character_flag = lahmianbanquet
+	clr_character_flag = killed_wife_success
+	clr_character_flag = killed_wife_failure
+	clr_character_flag = lahmiancomfort
+	clr_character_flag = lahmia12failed
+	clr_character_flag = return_home_lahmia
+	set_variable = { which = "seduction_progress" value = 0 }
+	if = {
+	limit = {
+	NOT = { trait = lahmian_queen }
+	}
+	any_playable_ruler = {
+	limit = { trait = lahmian_queen }
+	character_event = { id = lahmia.100 } ##100 is the failure event that the queen gets
+	}
+	}
+	}
+
+	}
+
+	##target refuses to stay the night at the ball and cuts her off from contact, chase is over
+	character_event = {
+	id = lahmia.34
+	title = LAHMIA_SEDUCTION
+	desc = lahmia34desc #Your target looks at you with shock when you offer him to stay the night, and coldly informs you that that would not be proper. He leaves in a hurry, and all attempts at further contact fails. It seems this chase is over... it's time to return home.
+	picture = "GFX_vampiress1"
+	hide_from = yes
+
+	is_triggered_only = yes
+
+	option = {
+	name = lahmia34A #Curses!
+	remove_trait = on_lahmian_mission
+	clr_character_flag = damselindistress
+	clr_character_flag = lahmianbanquet
+	clr_character_flag = killed_wife_success
+	clr_character_flag = killed_wife_failure
+	clr_character_flag = lahmiancomfort
+	clr_character_flag = lahmia12failed
+	clr_character_flag = return_home_lahmia
+	set_variable = { which = "seduction_progress" value = 0 }
+	if = {
+	limit = {
+	NOT = { trait = lahmian_queen }
+	}
+	any_playable_ruler = {
+	limit = { trait = lahmian_queen }
+	character_event = { id = lahmia.100 } ##100 is the failure event that the queen gets
+	}
+	}
+	}
+
+	}
+
+#lahmia.50 is the yearly maintenance event where you can ask for favors from your lovers, remember scope here is FROMFROM
+	long_character_event = {
+	id = lahmia.50
+	title = LAHMIA_SEDUCTION
+	desc = lahmia50desc #You have continued to infiltrate the layers of high society around your target, hosting lavish midnight balls and creating your own network of spies where your handmaidens manipulate and seduce the lesser actors in this game while you set the tune to which they dance. Your target is in the palm of your hand, he will not refuse you anything. What shall you ask for? Perhaps your funds are tied up in a business venture and you need some gold to maintain your lifestyle? Or perhaps your dear fictional friend or relative has lands under threat, and could use some soldiers to help her out?
+	picture = "GFX_evt_cultist"
+	hide_from = yes
+
+	is_triggered_only = yes
+
+	option = {
+	name = lahmia50C #I must return home.
+	trigger = {
+	AND = {
+	age = 1
+	OR = {
+	ai = no
+	has_character_flag = return_home_lahmia
+	}
+	}
+	}
+	remove_trait = on_lahmian_mission
+	clr_character_flag = damselindistress
+	clr_character_flag = lahmianbanquet
+	clr_character_flag = killed_wife_success
+	clr_character_flag = killed_wife_failure
+	clr_character_flag = lahmiancomfort
+	clr_character_flag = lahmia12failed
+	clr_character_flag = return_home_lahmia
+	set_variable = { which = "seduction_progress" value = 0 }
+	}
+
+
+	option = {
+	name = lahmia50A #Manipulate him into giving you gold
+	trigger = {
+	FROMFROM = { is_alive = yes }
+	NOT = { has_character_flag = return_home_lahmia }
+	}
+	if = {
+	limit = {
+	intrigue = 20
+	trait = beautiful
+	}
+	change_variable = { which = "seduction_progress" value = 5 }
+	}
+	if = {
+	limit = {
+	intrigue = 20
+	NOT = { trait = beautiful }
+	}
+	change_variable = { which = "seduction_progress" value = 4 }
+	}
+	if = {
+	limit = {
+	intrigue = 15
+	NOT = { intrigue = 16 }
+	}
+	change_variable = { which = "seduction_progress" value = 3 }
+	}
+	if = {
+	limit = {
+	intrigue = 10
+	NOT = { intrigue = 11 }
+	}
+	change_variable = { which = "seduction_progress" value = 2 }
+	}
+	if = {
+	limit = {
+	intrigue = 5
+	NOT = { intrigue = 6 }
+	}
+	change_variable = { which = "seduction_progress" value = 0.5 }
+	}
+	if = {
+	limit = {
+	NOT = { has_character_flag = lahmiancomfort }
+	}
+	FROMFROM = { long_character_event = { id = lahmia.51 } }
+	}
+	if = {
+	limit = {
+	has_character_flag = lahmiancomfort
+	}
+	FROMFROMFROM = { long_character_event = { id = lahmia.51 } }
+	clr_character_flag = lahmiancomfort
+	}
+	}
+
+	option = {
+	name = lahmia50B #Manipulate him into giving you troops
+	trigger = {
+	AND = {
+	age = 1
+	NOT = { has_character_flag = return_home_lahmia }
+	FROMFROM = { is_alive = yes }
+	}
+	}
+	if = {
+	limit = {
+	intrigue = 20
+	trait = beautiful
+	}
+	change_variable = { which = "seduction_progress" value = 5 }
+	}
+	if = {
+	limit = {
+	intrigue = 20
+	NOT = { trait = beautiful }
+	}
+	change_variable = { which = "seduction_progress" value = 4 }
+	}
+	if = {
+	limit = {
+	intrigue = 15
+	NOT = { intrigue = 16 }
+	}
+	change_variable = { which = "seduction_progress" value = 3 }
+	}
+	if = {
+	limit = {
+	intrigue = 10
+	NOT = { intrigue = 11 }
+	}
+	change_variable = { which = "seduction_progress" value = 2 }
+	}
+	if = {
+	limit = {
+	intrigue = 5
+	NOT = { intrigue = 6 }
+	}
+	change_variable = { which = "seduction_progress" value = 0.5 }
+	}
+	if = {
+	limit = {
+	NOT = { has_character_flag = lahmiancomfort }
+	}
+	FROMFROM = { long_character_event = { id = lahmia.56 } }
+	}
+	if = {
+	limit = {
+	has_character_flag = lahmiancomfort
+	}
+	FROMFROMFROM = { long_character_event = { id = lahmia.56 } }
+	clr_character_flag = lahmiancomfort
+	}
+	}
+
+	option = {
+	name = lahmiadeadtarget #Your target is dead. It's tme to go home.
+	trigger = {
+	AND = {
+	age = 1
+	FROMFROM = { is_alive = no }
+	NOT = { has_character_flag = return_home_lahmia }
+	}
+	}
+	remove_trait = on_lahmian_mission
+	clr_character_flag = damselindistress
+	clr_character_flag = lahmianbanquet
+	clr_character_flag = killed_wife_success
+	clr_character_flag = killed_wife_failure
+	clr_character_flag = lahmiancomfort
+	clr_character_flag = lahmia12failed
+	clr_character_flag = return_home_lahmia
+	set_variable = { which = "seduction_progress" value = 0 }
+	if = {
+	limit = {
+	NOT = { trait = lahmian_queen }
+	}
+	any_playable_ruler = {
+	limit = {
+	trait = lahmian_queen
+	}
+	character_event = { id = lahmia.101 } #101 informs the queen the target is dead and mission is over
+	}
+	}
+	}
+
+	}
+
+#lahmian asks for gold, target point of view
+	long_character_event = {
+	id = lahmia.51
+	title = LAHMIA_SEDUCTION
+	desc = lahmia51desc #While attending one of her lavish midnight balls, your dear heiress friend looking stunning as ever asks to speak to you privately. She looks distraught and on the verge of tears. It seems her steward has tied her money up in a risky business venture, and she fears she cannot maintain her estate at all if she cannot find the funds elsewhere. She would be humiliated, thrown out of her home, and forced to live like a commoner. She looks at you appealingly, and asks if you can do anything to help her out of her predicament?
+	picture = "GFX_evt_cultist"
+	hide_from = yes
+
+	is_triggered_only = yes
+
+	option = {
+	name = lahmia51A #My dear lady, let it trouble you no longer. I will help.
+ai_chance = {
+      factor = 75
+
+      modifier = {
+         factor = 2.0
+         trait = gregarious
+      }
+      modifier = {
+         factor = 2.0
+         trait = lustful
+      }
+      modifier = {
+         factor = 2.0
+         trait = hedonist
+      }
+      modifier = {
+         factor = 2.0
+         trait = ambitious
+      }
+      modifier = {
+         factor = 2.0
+         FROM = { intrigue = 10 }
+      }
+      modifier = {
+         factor = 2.0
+         FROM = { intrigue = 15 }
+      }
+      modifier = {
+         factor = 2.0
+         FROM = { intrigue = 20 }
+      }
+      modifier = {
+         factor = 2.0
+         FROM = { intrigue = 25 }
+      }
+      modifier = {
+         factor = 1.5
+         FROM = { trait = fair }
+      }
+      modifier = {
+         factor = 2.0
+         FROM = { trait = pretty }
+      }
+      modifier = {
+         factor = 3.0
+         FROM = { trait = beautiful }
+      }
+}
+	FROM = { character_event = { id = lahmia.52 days = 1 } } #lahmia gets money
+	character_event = { id = lahmia.53 days = 1 } #target gets rewarded
+	if = {
+	limit = {
+	tier = EMPEROR
+	FROM = { check_variable = { which = "seduction_progress" value = 50 }
+	}
+	wealth = -200
+	}
+	}
+	if = {
+	limit = {
+	tier = EMPEROR
+	FROM = { check_variable = { which = "seduction_progress" value = 25 } }
+	NOT = { FROM = { check_variable = { which = "seduction_progress" value = 50 }  } }
+	}
+	wealth = -150
+	}
+	if = {
+	limit = {
+	tier = EMPEROR
+	FROM = { check_variable = { which = "seduction_progress" value = 10 } }
+	NOT = { FROM = { check_variable = { which = "seduction_progress" value = 25 }  } }
+	}
+	wealth = -100
+	}
+	if = {
+	limit = {
+	tier = EMPEROR
+	FROM = { check_variable = { which = "seduction_progress" value = 1 } }
+	NOT = { FROM = { check_variable = { which = "seduction_progress" value = 10 }  } }
+	}
+	wealth = -50
+	}
+
+	if = {
+	limit = {
+	tier = KING
+	FROM = { check_variable = { which = "seduction_progress" value = 50 }
+	}
+	wealth = -150
+	}
+	}
+	if = {
+	limit = {
+	tier = KING
+	FROM = { check_variable = { which = "seduction_progress" value = 25 } }
+	NOT = { FROM = { check_variable = { which = "seduction_progress" value = 50 }  } }
+	}
+	wealth = -100
+	}
+	if = {
+	limit = {
+	tier = KING
+	FROM = { check_variable = { which = "seduction_progress" value = 10 } }
+	NOT = { FROM = { check_variable = { which = "seduction_progress" value = 25 }  } }
+	}
+	wealth = -75
+	}
+	if = {
+	limit = {
+	tier = KING
+	FROM = { check_variable = { which = "seduction_progress" value = 1 } }
+	NOT = { FROM = { check_variable = { which = "seduction_progress" value = 10 }  } }
+	}
+	wealth = -50
+	}
+
+	if = {
+	limit = {
+	tier = DUKE
+	FROM = { check_variable = { which = "seduction_progress" value = 50 }
+	}
+	wealth = -125
+	}
+	}
+	if = {
+	limit = {
+	tier = DUKE
+	FROM = { check_variable = { which = "seduction_progress" value = 25 } }
+	NOT = { FROM = { check_variable = { which = "seduction_progress" value = 50 }  } }
+	}
+	wealth = -75
+	}
+	if = {
+	limit = {
+	tier = DUKE
+	FROM = { check_variable = { which = "seduction_progress" value = 10 } }
+	NOT = { FROM = { check_variable = { which = "seduction_progress" value = 25 }  } }
+	}
+	wealth = -50
+	}
+	if = {
+	limit = {
+	tier = DUKE
+	FROM = { check_variable = { which = "seduction_progress" value = 1 } }
+	NOT = { FROM = { check_variable = { which = "seduction_progress" value = 10 }  } }
+	}
+	wealth = -25
+	}
+
+	if = {
+	limit = {
+	lower_tier_than = DUKE
+	FROM = { check_variable = { which = "seduction_progress" value = 50 }
+	}
+	wealth = -50
+	}
+	}
+	if = {
+	limit = {
+	lower_tier_than = DUKE
+	FROM = { check_variable = { which = "seduction_progress" value = 25 } }
+	NOT = { FROM = { check_variable = { which = "seduction_progress" value = 50 }  } }
+	}
+	wealth = -35
+	}
+	if = {
+	limit = {
+	lower_tier_than = DUKE
+	FROM = { check_variable = { which = "seduction_progress" value = 10 } }
+	NOT = { FROM = { check_variable = { which = "seduction_progress" value = 25 }  } }
+	}
+	wealth = -15
+	}
+	if = {
+	limit = {
+	lower_tier_than = DUKE
+	FROM = { check_variable = { which = "seduction_progress" value = 1 } }
+	NOT = { FROM = { check_variable = { which = "seduction_progress" value = 10 }  } }
+	}
+	wealth = -10
+	}
+	}
+
+
+	option = {
+	name = lahmia51B #No, I won't help with money.
+ai_chance = {
+      factor = 50
+
+	modifier = {
+         factor = 4.0
+         trait = greedy
+      }
+      modifier = {
+         factor = 2.0
+         trait = shy
+      }
+      modifier = {
+         factor = 2.0
+         trait = chaste
+      }
+      modifier = {
+         factor = 2.0
+         is_married = yes
+      }
+      modifier = {
+         factor = 8.0
+         trait = celibate
+      }
+      modifier = {
+         factor = 10.0
+         trait = homosexual
+      }
+      modifier = {
+         factor = 1.5
+         FROM = { trait = plain }
+      }
+      modifier = {
+         factor = 2.0
+         FROM = { trait = ugly }
+      }
+      modifier = {
+         factor = 3.0
+         FROM = { trait = unsightly }
+      }
+}
+	FROM = { character_event = { id = lahmia.54 days = 1 } }
+	character_event = { id = lahmia.55 days = 1 }
+	}
+
+	}
+
+#lahmian asks for gold, success, lahmia point of view
+	character_event = {
+	id = lahmia.52
+	title = LAHMIA_SEDUCTION
+	desc = lahmia52desc #Your benefactor agrees to support your lifestyle with his own funds until yours are once more liquid, and you make sure he is well rewarded for his generosity.
+	picture = "GFX_vampiress1"
+	hide_from = yes
+
+	is_triggered_only = yes
+
+	option = {
+	name = lahmia52A #This game continues to delight! Now I'll send these to my queen.
+	trigger = {
+	NOT = { trait = lahmian_queen }
+	}
+	ROOT = { long_character_event = { id = lahmia.50 days = 365 } } ##lahmia.50 is the yearly maintenance event where you can ask for favors from your lovers
+	if = {
+	limit = {
+	FROM = { tier = EMPEROR }
+	check_variable = { which = "seduction_progress" value = 50 }
+	}
+	any_playable_ruler = {
+	limit = {
+	trait = lahmian_queen
+	}
+	character_event = { id = lahmia.102 } #102 is the event where the queen gets informed her daughters have sent her gold
+	wealth = 200
+	}
+	}
+	if = {
+	limit = {
+	FROM = { tier = EMPEROR }
+	check_variable = { which = "seduction_progress" value = 25 }
+	NOT = { check_variable = { which = "seduction_progress" value = 50 }  }
+	}
+	any_playable_ruler = {
+	limit = {
+	trait = lahmian_queen
+	}
+	character_event = { id = lahmia.102 } #102 is the event where the queen gets informed her daughters have sent her gold
+	wealth = 150
+	}
+	}
+	if = {
+	limit = {
+	FROM = { tier = EMPEROR }
+	check_variable = { which = "seduction_progress" value = 10 }
+	NOT = { check_variable = { which = "seduction_progress" value = 25 } }
+	}
+	any_playable_ruler = {
+	limit = {
+	trait = lahmian_queen
+	}
+	character_event = { id = lahmia.102 } #102 is the event where the queen gets informed her daughters have sent her gold
+	wealth = 100
+	}
+	}
+	if = {
+	limit = {
+	FROM = { tier = EMPEROR }
+	check_variable = { which = "seduction_progress" value = 1 }
+	NOT = { check_variable = { which = "seduction_progress" value = 10 } }
+	}
+	any_playable_ruler = {
+	limit = {
+	trait = lahmian_queen
+	}
+	character_event = { id = lahmia.102 } #102 is the event where the queen gets informed her daughters have sent her gold
+	wealth = 50
+	}
+	}
+
+	if = {
+	limit = {
+	FROM = { tier = KING }
+	check_variable = { which = "seduction_progress" value = 50 }
+	}
+	any_playable_ruler = {
+	limit = {
+	trait = lahmian_queen
+	}
+	character_event = { id = lahmia.102 } #102 is the event where the queen gets informed her daughters have sent her gold
+	wealth = 150
+	}
+	}
+	if = {
+	limit = {
+	FROM = { tier = KING }
+	check_variable = { which = "seduction_progress" value = 25 }
+	NOT = { check_variable = { which = "seduction_progress" value = 50 } }
+	}
+	any_playable_ruler = {
+	limit = {
+	trait = lahmian_queen
+	}
+	character_event = { id = lahmia.102 } #102 is the event where the queen gets informed her daughters have sent her gold
+	wealth = 100
+	}
+	}
+	if = {
+	limit = {
+	FROM = { tier = KING }
+	check_variable = { which = "seduction_progress" value = 10 }
+	NOT = { check_variable = { which = "seduction_progress" value = 25 } }
+	}
+	any_playable_ruler = {
+	limit = {
+	trait = lahmian_queen
+	}
+	character_event = { id = lahmia.102 } #102 is the event where the queen gets informed her daughters have sent her gold
+	wealth = 75
+	}
+	}
+	if = {
+	limit = {
+	FROM = { tier = KING }
+	check_variable = { which = "seduction_progress" value = 1 }
+	NOT = { check_variable = { which = "seduction_progress" value = 10 } }
+	}
+	any_playable_ruler = {
+	limit = {
+	trait = lahmian_queen
+	}
+	character_event = { id = lahmia.102 } #102 is the event where the queen gets informed her daughters have sent her gold
+	wealth = 50
+	}
+	}
+
+	if = {
+	limit = {
+	FROM = { tier = DUKE }
+	check_variable = { which = "seduction_progress" value = 50 }
+	}
+	any_playable_ruler = {
+	limit = {
+	trait = lahmian_queen
+	}
+	character_event = { id = lahmia.102 } #102 is the event where the queen gets informed her daughters have sent her gold
+	wealth = 125
+	}
+	}
+	if = {
+	limit = {
+	FROM = { tier = DUKE }
+ 	check_variable = { which = "seduction_progress" value = 25 }
+	NOT = { check_variable = { which = "seduction_progress" value = 50 } }
+	}
+	any_playable_ruler = {
+	limit = {
+	trait = lahmian_queen
+	}
+	character_event = { id = lahmia.102 } #102 is the event where the queen gets informed her daughters have sent her gold
+	wealth = 75
+	}
+	}
+	if = {
+	limit = {
+	FROM = { tier = DUKE }
+	check_variable = { which = "seduction_progress" value = 10 }
+	NOT = { check_variable = { which = "seduction_progress" value = 25 } }
+	}
+	any_playable_ruler = {
+	limit = {
+	trait = lahmian_queen
+	}
+	character_event = { id = lahmia.102 } #102 is the event where the queen gets informed her daughters have sent her gold
+	wealth = 50
+	}
+	}
+	if = {
+	limit = {
+	FROM = { tier = DUKE }
+	check_variable = { which = "seduction_progress" value = 1 }
+	NOT = { check_variable = { which = "seduction_progress" value = 10 } }
+	}
+	any_playable_ruler = {
+	limit = {
+	trait = lahmian_queen
+	}
+	character_event = { id = lahmia.102 } #102 is the event where the queen gets informed her daughters have sent her gold
+	wealth = 25
+	}
+	}
+
+	if = {
+	limit = {
+	FROM = { lower_tier_than = DUKE }
+	check_variable = { which = "seduction_progress" value = 50 }
+	}
+	any_playable_ruler = {
+	limit = {
+	trait = lahmian_queen
+	}
+	character_event = { id = lahmia.102 } #102 is the event where the queen gets informed her daughters have sent her gold
+	wealth = 50
+	}
+	}
+	if = {
+	limit = {
+	FROM = { lower_tier_than = DUKE }
+ 	check_variable = { which = "seduction_progress" value = 25 }
+	NOT = { check_variable = { which = "seduction_progress" value = 50 } }
+	}
+	any_playable_ruler = {
+	limit = {
+	trait = lahmian_queen
+	}
+	character_event = { id = lahmia.102 } #102 is the event where the queen gets informed her daughters have sent her gold
+	wealth = 35
+	}
+	}
+	if = {
+	limit = {
+	FROM = { lower_tier_than = DUKE }
+	check_variable = { which = "seduction_progress" value = 10 }
+	NOT = { check_variable = { which = "seduction_progress" value = 25 } }
+	}
+	any_playable_ruler = {
+	limit = {
+	trait = lahmian_queen
+	}
+	character_event = { id = lahmia.102 } #102 is the event where the queen gets informed her daughters have sent her gold
+	wealth = 20
+	}
+	}
+	if = {
+	limit = {
+	FROM = { lower_tier_than = DUKE }
+	check_variable = { which = "seduction_progress" value = 1 }
+	NOT = { check_variable = { which = "seduction_progress" value = 10 } }
+	}
+	any_playable_ruler = {
+	limit = {
+	trait = lahmian_queen
+	}
+	character_event = { id = lahmia.102 } #102 is the event where the queen gets informed her daughters have sent her gold
+	wealth = 10
+	}
+	}
+
+	}
+
+	option = {
+	name = lahmia52B #This game continues to delight!
+	trigger = {
+	trait = lahmian_queen
+	}
+	ROOT = { long_character_event = { id = lahmia.50 days = 365 } } ##lahmia.50 is the yearly maintenance event where you can ask for favors from your lovers
+	if = {
+	limit = {
+	FROM = { tier = EMPEROR }
+	check_variable = { which = "seduction_progress" value = 50 }
+	}
+	wealth = 200
+	}
+	if = {
+	limit = {
+	FROM = { tier = EMPEROR }
+	check_variable = { which = "seduction_progress" value = 25 }
+	NOT = { check_variable = { which = "seduction_progress" value = 50 }  }
+	}
+	wealth = 150
+	}
+	if = {
+	limit = {
+	FROM = { tier = EMPEROR }
+	check_variable = { which = "seduction_progress" value = 10 }
+	NOT = { check_variable = { which = "seduction_progress" value = 25 } }
+	}
+	wealth = 100
+	}
+	if = {
+	limit = {
+	FROM = { tier = EMPEROR }
+	check_variable = { which = "seduction_progress" value = 1 }
+	NOT = { check_variable = { which = "seduction_progress" value = 10 } }
+	}
+	wealth = 50
+	}
+
+	if = {
+	limit = {
+	FROM = { tier = KING }
+	check_variable = { which = "seduction_progress" value = 50 }
+	}
+	wealth = 150
+	}
+	if = {
+	limit = {
+	FROM = { tier = KING }
+	check_variable = { which = "seduction_progress" value = 25 }
+	NOT = { check_variable = { which = "seduction_progress" value = 50 } }
+	}
+	wealth = 100
+	}
+	if = {
+	limit = {
+	FROM = { tier = KING }
+	check_variable = { which = "seduction_progress" value = 10 }
+	NOT = { check_variable = { which = "seduction_progress" value = 25 } }
+	}
+	wealth = 75
+	}
+	if = {
+	limit = {
+	FROM = { tier = KING }
+	check_variable = { which = "seduction_progress" value = 1 }
+	NOT = { check_variable = { which = "seduction_progress" value = 10 } }
+	}
+	wealth = 50
+	}
+
+	if = {
+	limit = {
+	FROM = { tier = DUKE }
+	check_variable = { which = "seduction_progress" value = 50 }
+	}
+	wealth = 125
+	}
+	if = {
+	limit = {
+	FROM = { tier = DUKE }
+ 	check_variable = { which = "seduction_progress" value = 25 }
+	NOT = { check_variable = { which = "seduction_progress" value = 50 } }
+	}
+	wealth = 75
+	}
+	if = {
+	limit = {
+	FROM = { tier = DUKE }
+	check_variable = { which = "seduction_progress" value = 10 }
+	NOT = { check_variable = { which = "seduction_progress" value = 25 } }
+	}
+	wealth = 50
+	}
+	if = {
+	limit = {
+	FROM = { tier = DUKE }
+	check_variable = { which = "seduction_progress" value = 1 }
+	NOT = { check_variable = { which = "seduction_progress" value = 10 } }
+	}
+	wealth = 25
+	}
+
+	if = {
+	limit = {
+	FROM = { lower_tier_than = DUKE }
+	check_variable = { which = "seduction_progress" value = 50 }
+	}
+	wealth = 50
+	}
+	if = {
+	limit = {
+	FROM = { lower_tier_than = DUKE }
+ 	check_variable = { which = "seduction_progress" value = 25 }
+	NOT = { check_variable = { which = "seduction_progress" value = 50 } }
+	}
+	wealth = 35
+	}
+	if = {
+	limit = {
+	FROM = { lower_tier_than = DUKE }
+	check_variable = { which = "seduction_progress" value = 10 }
+	NOT = { check_variable = { which = "seduction_progress" value = 25 } }
+	}
+	wealth = 15
+	}
+	if = {
+	limit = {
+	FROM = { lower_tier_than = DUKE }
+	check_variable = { which = "seduction_progress" value = 1 }
+	NOT = { check_variable = { which = "seduction_progress" value = 10 } }
+	}
+	wealth = 10
+	}
+
+	}
+
+	}
+
+
+	##target gets his reward
+	character_event = {
+	id = lahmia.53
+	title = LAHMIA_SEDUCTION
+	desc = lahmia53desc #Your dear lady friend is delighted, and you are richly rewarded for your generosity over the coming days and weeks. You are pleased with yourself, as the city would be such a dull place without her stunning beauty, lavish parties and clever wit. She really is the center of high society in many ways.
+	picture = "GFX_vampiress1"
+	hide_from = yes
+
+	is_triggered_only = yes
+
+	option = {
+	name = lahmia53A #I couldn't let such a noble lady live like a commoner...
+	}
+
+	}
+
+	##target refuses to help with money, lahmia is informed
+	character_event = {
+	id = lahmia.54
+	title = LAHMIA_SEDUCTION
+	desc = lahmia54desc #Curses! Your target is apparently not so easily manipulated... he refuses to help you with money, which makes him useless to you. All this work wasted... it is time to return home.
+	picture = "GFX_evt_cultist"
+	hide_from = yes
+
+	is_triggered_only = yes
+
+	option = {
+	name = lahmia54A #That arrogant mortal, I should rip his throat out...
+	remove_trait = on_lahmian_mission
+	clr_character_flag = damselindistress
+	clr_character_flag = lahmianbanquet
+	clr_character_flag = killed_wife_success
+	clr_character_flag = killed_wife_failure
+	clr_character_flag = lahmiancomfort
+	clr_character_flag = lahmia12failed
+	clr_character_flag = return_home_lahmia
+	set_variable = { which = "seduction_progress" value = 0 }
+	if = {
+	limit = {
+	NOT = { trait = lahmian_queen }
+	}
+	any_playable_ruler = {
+	limit = { trait = lahmian_queen }
+	character_event = { id = lahmia.100 } ##100 is the failure event that the queen gets
+	}
+	}
+	}
+
+	}
+
+	##target refuses to help with money, target is informed that heiress has left
+	character_event = {
+	id = lahmia.55
+	desc = lahmia55desc #You refuse to help out the heiress with money, and despite her pleas, you leave the ball without helping her. The next day, you are informed that she has packed up and left the city.
+	picture = "GFX_evt_cultist"
+	hide_from = yes
+
+	is_triggered_only = yes
+
+	option = {
+	name = lahmia55A #A shame. I think I'll miss her.
+	}
+
+	}
+
+#lahmian asks for troops, target point of view
+	long_character_event = {
+	id = lahmia.56
+	title = LAHMIA_SEDUCTION
+	desc = lahmia56desc #While attending one of her lavish balls, your dear heiress friend looking stunning as ever asks to speak to you privately. She looks distraught and on the verge of tears. It seems a dear elderly aunt has lands that are under threat, and she doesn't know what to do to help. She looks at you appealingly, and asks that if you are powerful enough to send some troops to her aid?
+	picture = "GFX_evt_cultist"
+	hide_from = yes
+
+	is_triggered_only = yes
+
+	option = {
+	name = lahmia56A #I will outfit an expedition immediately to clear her lands!
+ai_chance = {
+      factor = 75
+
+      modifier = {
+         factor = 2.0
+         trait = gregarious
+      }
+      modifier = {
+         factor = 2.0
+         trait = lustful
+      }
+      modifier = {
+         factor = 2.0
+         trait = hedonist
+      }
+      modifier = {
+         factor = 2.0
+         trait = ambitious
+      }
+      modifier = {
+         factor = 2.0
+         FROM = { intrigue = 10 }
+      }
+      modifier = {
+         factor = 2.0
+         FROM = { intrigue = 15 }
+      }
+      modifier = {
+         factor = 2.0
+         FROM = { intrigue = 20 }
+      }
+      modifier = {
+         factor = 2.0
+         FROM = { intrigue = 25 }
+      }
+      modifier = {
+         factor = 1.5
+         FROM = { trait = fair }
+      }
+      modifier = {
+         factor = 2.0
+         FROM = { trait = pretty }
+      }
+      modifier = {
+         factor = 3.0
+         FROM = { trait = beautiful }
+      }
+}
+	FROM = { character_event = { id = lahmia.57 days = 1 } } #lahmia gets troops
+	character_event = { id = lahmia.58 days = 1 } #target gets rewarded
+	if = {
+	limit = {
+	tier = EMPEROR
+	FROM = { check_variable = { which = "seduction_progress" value = 50 }
+	}
+	wealth = -100
+	}
+	}
+	if = {
+	limit = {
+	tier = EMPEROR
+	FROM = { check_variable = { which = "seduction_progress" value = 25 } }
+	NOT = { FROM = { check_variable = { which = "seduction_progress" value = 50 }  } }
+	}
+	wealth = -75
+	}
+	if = {
+	limit = {
+	tier = EMPEROR
+	FROM = { check_variable = { which = "seduction_progress" value = 10 } }
+	NOT = { FROM = { check_variable = { which = "seduction_progress" value = 25 }  } }
+	}
+	wealth = -50
+	}
+	if = {
+	limit = {
+	tier = EMPEROR
+	FROM = { check_variable = { which = "seduction_progress" value = 1 } }
+	NOT = { FROM = { check_variable = { which = "seduction_progress" value = 10 }  } }
+	}
+	wealth = -25
+	}
+
+	if = {
+	limit = {
+	tier = KING
+	FROM = { check_variable = { which = "seduction_progress" value = 50 }
+	}
+	wealth = -75
+	}
+	}
+	if = {
+	limit = {
+	tier = KING
+	FROM = { check_variable = { which = "seduction_progress" value = 25 } }
+	NOT = { FROM = { check_variable = { which = "seduction_progress" value = 50 }  } }
+	}
+	wealth = -50
+	}
+	if = {
+	limit = {
+	tier = KING
+	FROM = { check_variable = { which = "seduction_progress" value = 10 } }
+	NOT = { FROM = { check_variable = { which = "seduction_progress" value = 25 }  } }
+	}
+	wealth = -35
+	}
+	if = {
+	limit = {
+	tier = KING
+	FROM = { check_variable = { which = "seduction_progress" value = 1 } }
+	NOT = { FROM = { check_variable = { which = "seduction_progress" value = 10 }  } }
+	}
+	wealth = -25
+	}
+
+	if = {
+	limit = {
+	tier = DUKE
+	FROM = { check_variable = { which = "seduction_progress" value = 50 }
+	}
+	wealth = -70
+	}
+	}
+	if = {
+	limit = {
+	tier = DUKE
+	FROM = { check_variable = { which = "seduction_progress" value = 25 } }
+	NOT = { FROM = { check_variable = { which = "seduction_progress" value = 50 }  } }
+	}
+	wealth = -40
+	}
+	if = {
+	limit = {
+	tier = DUKE
+	FROM = { check_variable = { which = "seduction_progress" value = 10 } }
+	NOT = { FROM = { check_variable = { which = "seduction_progress" value = 25 }  } }
+	}
+	wealth = -20
+	}
+	if = {
+	limit = {
+	tier = DUKE
+	FROM = { check_variable = { which = "seduction_progress" value = 1 } }
+	NOT = { FROM = { check_variable = { which = "seduction_progress" value = 10 }  } }
+	}
+	wealth = -10
+	}
+
+	if = {
+	limit = {
+	lower_tier_than = DUKE
+	FROM = { check_variable = { which = "seduction_progress" value = 50 }
+	}
+	wealth = -25
+	}
+	}
+	if = {
+	limit = {
+	lower_tier_than = DUKE
+	FROM = { check_variable = { which = "seduction_progress" value = 25 } }
+	NOT = { FROM = { check_variable = { which = "seduction_progress" value = 50 }  } }
+	}
+	wealth = -20
+	}
+	if = {
+	limit = {
+	lower_tier_than = DUKE
+	FROM = { check_variable = { which = "seduction_progress" value = 10 } }
+	NOT = { FROM = { check_variable = { which = "seduction_progress" value = 25 }  } }
+	}
+	wealth = -15
+	}
+	if = {
+	limit = {
+	lower_tier_than = DUKE
+	FROM = { check_variable = { which = "seduction_progress" value = 1 } }
+	NOT = { FROM = { check_variable = { which = "seduction_progress" value = 10 }  } }
+	}
+	wealth = -10
+	}
+	}
+
+
+	option = {
+	name = lahmia56B #No, I won't help with troops.
+ai_chance = {
+      factor = 50
+
+      modifier = {
+         factor = 2.0
+         trait = craven
+      }
+      modifier = {
+         factor = 4.0
+         trait = chaste
+      }
+      modifier = {
+         factor = 8.0
+         trait = celibate
+      }
+      modifier = {
+         factor = 10.0
+         trait = homosexual
+      }
+      modifier = {
+         factor = 1.5
+         FROM = { trait = plain }
+      }
+      modifier = {
+         factor = 2.0
+         FROM = { trait = ugly }
+      }
+      modifier = {
+         factor = 3.0
+         FROM = { trait = unsightly }
+      }
+}
+	FROM = { character_event = { id = lahmia.59 days = 1 } }
+	character_event = { id = lahmia.60 days = 1 }
+	}
+
+	}
+
+#lahmian asks for gold, success, lahmia point of view
+	character_event = {
+	id = lahmia.57
+	title = LAHMIA_SEDUCTION
+	desc = lahmia57desc #Your benefactor agrees to send troops to your endangered relative, and you make sure he is well rewarded for his generosity.
+	picture = "GFX_vampiress1"
+	hide_from = yes
+
+	is_triggered_only = yes
+
+	option = {
+	name = lahmia57A #This game continues to delight! Now I'll send these to my queen.
+	trigger = {
+	NOT = { trait = lahmian_queen }
+	}
+	ROOT = { long_character_event = { id = lahmia.50 days = 365 } }	##lahmia.50 is the yearly maintenance event where you can ask for favors from your lovers
+	if = {
+	limit = {
+	FROM = { tier = EMPEROR }
+	check_variable = { which = "seduction_progress" value = 50 }
+	}
+	any_playable_ruler = {
+	limit = {
+	trait = lahmian_queen
+	}
+	character_event = { id = lahmia.103 } #103 is the event where the queen gets informed her daughters have sent her troops
+	location = {
+			ROOT = {
+				spawn_unit = {
+					province = PREV
+					troops = {
+						knights = {	25 25 }
+						heavy_infantry = {	25 25 }
+						archers = {	25 25 }
+					}
+				}
+			}
+		}
+	}
+	}
+	if = {
+	limit = {
+	FROM = { tier = EMPEROR }
+	check_variable = { which = "seduction_progress" value = 25 }
+	NOT = { check_variable = { which = "seduction_progress" value = 50 }  }
+	}
+	any_playable_ruler = {
+	limit = {
+	trait = lahmian_queen
+	}
+	character_event = { id = lahmia.103 } #103 is the event where the queen gets informed her daughters have sent her troops
+	location = {
+			ROOT = {
+				spawn_unit = {
+					province = PREV
+					troops = {
+						knights = {	15 15 }
+						heavy_infantry = {	15 15 }
+						archers = {	25 25 }
+					}
+				}
+			}
+		}
+	}
+	}
+	if = {
+	limit = {
+	FROM = { tier = EMPEROR }
+	check_variable = { which = "seduction_progress" value = 10 }
+	NOT = { check_variable = { which = "seduction_progress" value = 25 } }
+	}
+	any_playable_ruler = {
+	limit = {
+	trait = lahmian_queen
+	}
+	character_event = { id = lahmia.103 } #103 is the event where the queen gets informed her daughters have sent her troops
+	location = {
+			ROOT = {
+				spawn_unit = {
+					province = PREV
+					troops = {
+						knights = {	10 10 }
+						heavy_infantry = {	10 10 }
+						pikemen = {	10 10 }
+						archers = {	25 25 }
+					}
+				}
+			}
+		}
+	}
+	}
+	if = {
+	limit = {
+	FROM = { tier = EMPEROR }
+	check_variable = { which = "seduction_progress" value = 1 }
+	NOT = { check_variable = { which = "seduction_progress" value = 10 } }
+	}
+	any_playable_ruler = {
+	limit = {
+	trait = lahmian_queen
+	}
+	character_event = { id = lahmia.103 } #103 is the event where the queen gets informed her daughters have sent her troops
+	location = {
+			ROOT = {
+				spawn_unit = {
+					province = PREV
+					troops = {
+						heavy_infantry = {	25 25 }
+						archers = {	25 25 }
+					}
+				}
+			}
+		}
+	}
+	}
+
+	if = {
+	limit = {
+	FROM = { tier = KING }
+	check_variable = { which = "seduction_progress" value = 50 }
+	}
+	any_playable_ruler = {
+	limit = {
+	trait = lahmian_queen
+	}
+	character_event = { id = lahmia.103 } #103 is the event where the queen gets informed her daughters have sent her troops
+	location = {
+			ROOT = {
+				spawn_unit = {
+					province = PREV
+					troops = {
+						knights = { 10 10 }
+						heavy_infantry = {	25 25 }
+						archers = {	25 25 }
+					}
+				}
+			}
+		}
+	}
+	}
+	if = {
+	limit = {
+	FROM = { tier = KING }
+	check_variable = { which = "seduction_progress" value = 25 }
+	NOT = { check_variable = { which = "seduction_progress" value = 50 } }
+	}
+	any_playable_ruler = {
+	limit = {
+	trait = lahmian_queen
+	}
+	character_event = { id = lahmia.103 } #103 is the event where the queen gets informed her daughters have sent her troops
+	location = {
+			ROOT = {
+				spawn_unit = {
+					province = PREV
+					troops = {
+						knights = { 5 5 }
+						heavy_infantry = {	15 15 }
+						archers = {	25 25 }
+					}
+				}
+			}
+		}
+	}
+	}
+	if = {
+	limit = {
+	FROM = { tier = KING }
+	check_variable = { which = "seduction_progress" value = 10 }
+	NOT = { check_variable = { which = "seduction_progress" value = 25 } }
+	}
+	any_playable_ruler = {
+	limit = {
+	trait = lahmian_queen
+	}
+	character_event = { id = lahmia.103 } #103 is the event where the queen gets informed her daughters have sent her troops
+	location = {
+			ROOT = {
+				spawn_unit = {
+					province = PREV
+					troops = {
+						heavy_infantry = {	15 15 }
+						archers = {	25 25 }
+					}
+				}
+			}
+		}
+	}
+	}
+	if = {
+	limit = {
+	FROM = { tier = KING }
+	check_variable = { which = "seduction_progress" value = 1 }
+	NOT = { check_variable = { which = "seduction_progress" value = 10 } }
+	}
+	any_playable_ruler = {
+	limit = {
+	trait = lahmian_queen
+	}
+	character_event = { id = lahmia.103 } #103 is the event where the queen gets informed her daughters have sent her troops
+	location = {
+			ROOT = {
+				spawn_unit = {
+					province = PREV
+					troops = {
+						heavy_infantry = {	10 10 }
+						archers = {	25 25 }
+					}
+				}
+			}
+		}
+	}
+	}
+
+	if = {
+	limit = {
+	FROM = { tier = DUKE }
+	check_variable = { which = "seduction_progress" value = 50 }
+	}
+	any_playable_ruler = {
+	limit = {
+	trait = lahmian_queen
+	}
+	character_event = { id = lahmia.103 } #103 is the event where the queen gets informed her daughters have sent her troops
+	location = {
+			ROOT = {
+				spawn_unit = {
+					province = PREV
+					troops = {
+						heavy_infantry = {	15 15 }
+						archers = {	25 25 }
+					}
+				}
+			}
+		}
+	}
+	}
+	if = {
+	limit = {
+	FROM = { tier = DUKE }
+ 	check_variable = { which = "seduction_progress" value = 25 }
+	NOT = { check_variable = { which = "seduction_progress" value = 50 } }
+	}
+	any_playable_ruler = {
+	limit = {
+	trait = lahmian_queen
+	}
+	character_event = { id = lahmia.103 } #103 is the event where the queen gets informed her daughters have sent her troops
+	location = {
+			ROOT = {
+				spawn_unit = {
+					province = PREV
+					troops = {
+						heavy_infantry = {	5 5 }
+						light_infantry = { 15 15 }
+						archers = {	25 25 }
+					}
+				}
+			}
+		}
+	}
+	}
+	if = {
+	limit = {
+	FROM = { tier = DUKE }
+	check_variable = { which = "seduction_progress" value = 10 }
+	NOT = { check_variable = { which = "seduction_progress" value = 25 } }
+	}
+	any_playable_ruler = {
+	limit = {
+	trait = lahmian_queen
+	}
+	character_event = { id = lahmia.103 } #103 is the event where the queen gets informed her daughters have sent her troops
+	location = {
+			ROOT = {
+				spawn_unit = {
+					province = PREV
+					troops = {
+						light_infantry = { 25 25 }
+						archers = {	25 25 }
+					}
+				}
+			}
+		}
+	}
+	}
+	if = {
+	limit = {
+	FROM = { tier = DUKE }
+	check_variable = { which = "seduction_progress" value = 1 }
+	NOT = { check_variable = { which = "seduction_progress" value = 10 } }
+	}
+	any_playable_ruler = {
+	limit = {
+	trait = lahmian_queen
+	}
+	character_event = { id = lahmia.103 } #103 is the event where the queen gets informed her daughters have sent her troops
+	location = {
+			ROOT = {
+				spawn_unit = {
+					province = PREV
+					troops = {
+						light_infantry = { 15 15 }
+						archers = {	15 15 }
+					}
+				}
+			}
+		}
+	}
+	}
+
+	if = {
+	limit = {
+	FROM = { lower_tier_than = DUKE }
+	check_variable = { which = "seduction_progress" value = 50 }
+	}
+	any_playable_ruler = {
+	limit = {
+	trait = lahmian_queen
+	}
+	character_event = { id = lahmia.103 } #103 is the event where the queen gets informed her daughters have sent her troops
+	location = {
+			ROOT = {
+				spawn_unit = {
+					province = PREV
+					troops = {
+						light_infantry = { 30 30 }
+						archers = {	15 15 }
+					}
+				}
+			}
+		}
+	}
+	}
+	if = {
+	limit = {
+	FROM = { lower_tier_than = DUKE }
+ 	check_variable = { which = "seduction_progress" value = 25 }
+	NOT = { check_variable = { which = "seduction_progress" value = 50 } }
+	}
+	any_playable_ruler = {
+	limit = {
+	trait = lahmian_queen
+	}
+	character_event = { id = lahmia.103 } #103 is the event where the queen gets informed her daughters have sent her troops
+	location = {
+			ROOT = {
+				spawn_unit = {
+					province = PREV
+					troops = {
+						light_infantry = { 20 20 }
+						archers = {	10 10 }
+					}
+				}
+			}
+		}
+	}
+	}
+	if = {
+	limit = {
+	FROM = { lower_tier_than = DUKE }
+	check_variable = { which = "seduction_progress" value = 10 }
+	NOT = { check_variable = { which = "seduction_progress" value = 25 } }
+	}
+	any_playable_ruler = {
+	limit = {
+	trait = lahmian_queen
+	}
+	character_event = { id = lahmia.103 } #103 is the event where the queen gets informed her daughters have sent her troops
+	location = {
+			ROOT = {
+				spawn_unit = {
+					province = PREV
+					troops = {
+						light_infantry = { 15 15 }
+						archers = {	10 10 }
+					}
+				}
+			}
+		}
+	}
+	}
+	if = {
+	limit = {
+	FROM = { lower_tier_than = DUKE }
+	check_variable = { which = "seduction_progress" value = 1 }
+	NOT = { check_variable = { which = "seduction_progress" value = 10 } }
+	}
+	any_playable_ruler = {
+	limit = {
+	trait = lahmian_queen
+	}
+	character_event = { id = lahmia.103 } #103 is the event where the queen gets informed her daughters have sent her troops
+	location = {
+			ROOT = {
+				spawn_unit = {
+					province = PREV
+					troops = {
+						light_infantry = { 15 15 }
+					}
+				}
+			}
+		}
+	}
+	}
+
+	}
+
+	option = {
+	name = lahmia57B #This game continues to delight!
+	trigger = {
+	trait = lahmian_queen
+	}
+	ROOT = { long_character_event = { id = lahmia.50 days = 365 } }##lahmia.50 is the yearly maintenance event where you can ask for favors from your lovers
+	if = {
+	limit = {
+	FROM = { tier = EMPEROR }
+	check_variable = { which = "seduction_progress" value = 50 }
+	}
+	location = {
+			ROOT = {
+				spawn_unit = {
+					province = PREV
+					troops = {
+						knights = {	25 25 }
+						heavy_infantry = {	25 25 }
+						archers = {	25 25 }
+					}
+				}
+			}
+		}
+	}
+	if = {
+	limit = {
+	FROM = { tier = EMPEROR }
+	check_variable = { which = "seduction_progress" value = 25 }
+	NOT = { check_variable = { which = "seduction_progress" value = 50 }  }
+	}
+		location = {
+			ROOT = {
+				spawn_unit = {
+					province = PREV
+					troops = {
+						knights = {	15 15 }
+						heavy_infantry = {	15 15 }
+						archers = {	25 25 }
+					}
+				}
+			}
+		}
+	}
+	if = {
+	limit = {
+	FROM = { tier = EMPEROR }
+	check_variable = { which = "seduction_progress" value = 10 }
+	NOT = { check_variable = { which = "seduction_progress" value = 25 } }
+	}
+	location = {
+			ROOT = {
+				spawn_unit = {
+					province = PREV
+					troops = {
+						knights = {	10 10 }
+						heavy_infantry = {	10 10 }
+						pikemen = {	10 10 }
+						archers = {	25 25 }
+					}
+				}
+			}
+		}
+	}
+	if = {
+	limit = {
+	FROM = { tier = EMPEROR }
+	check_variable = { which = "seduction_progress" value = 1 }
+	NOT = { check_variable = { which = "seduction_progress" value = 10 } }
+	}
+	location = {
+			ROOT = {
+				spawn_unit = {
+					province = PREV
+					troops = {
+						heavy_infantry = {	25 25 }
+						archers = {	25 25 }
+					}
+				}
+			}
+		}
+	}
+
+	if = {
+	limit = {
+	FROM = { tier = KING }
+	check_variable = { which = "seduction_progress" value = 50 }
+	}
+location = {
+			ROOT = {
+				spawn_unit = {
+					province = PREV
+					troops = {
+						knights = { 10 10 }
+						heavy_infantry = {	25 25 }
+						archers = {	25 25 }
+					}
+				}
+			}
+		}
+	}
+	if = {
+	limit = {
+	FROM = { tier = KING }
+	check_variable = { which = "seduction_progress" value = 25 }
+	NOT = { check_variable = { which = "seduction_progress" value = 50 } }
+	}
+	location = {
+			ROOT = {
+				spawn_unit = {
+					province = PREV
+					troops = {
+						knights = { 5 5 }
+						heavy_infantry = {	15 15 }
+						archers = {	25 25 }
+					}
+				}
+			}
+		}
+	}
+	if = {
+	limit = {
+	FROM = { tier = KING }
+	check_variable = { which = "seduction_progress" value = 10 }
+	NOT = { check_variable = { which = "seduction_progress" value = 25 } }
+	}
+	location = {
+			ROOT = {
+				spawn_unit = {
+					province = PREV
+					troops = {
+						heavy_infantry = {	15 15 }
+						archers = {	25 25 }
+					}
+				}
+			}
+		}
+	}
+	if = {
+	limit = {
+	FROM = { tier = KING }
+	check_variable = { which = "seduction_progress" value = 1 }
+	NOT = { check_variable = { which = "seduction_progress" value = 10 } }
+	}
+	location = {
+			ROOT = {
+				spawn_unit = {
+					province = PREV
+					troops = {
+						heavy_infantry = {	10 10 }
+						archers = {	25 25 }
+					}
+				}
+			}
+		}
+	}
+
+	if = {
+	limit = {
+	FROM = { tier = DUKE }
+	check_variable = { which = "seduction_progress" value = 50 }
+	}
+	location = {
+			ROOT = {
+				spawn_unit = {
+					province = PREV
+					troops = {
+						heavy_infantry = {	15 15 }
+						archers = {	25 25 }
+					}
+				}
+			}
+		}
+	}
+	if = {
+	limit = {
+	FROM = { tier = DUKE }
+ 	check_variable = { which = "seduction_progress" value = 25 }
+	NOT = { check_variable = { which = "seduction_progress" value = 50 } }
+	}
+	location = {
+			ROOT = {
+				spawn_unit = {
+					province = PREV
+					troops = {
+						heavy_infantry = {	5 5 }
+						light_infantry = { 15 15 }
+						archers = {	25 25 }
+					}
+				}
+			}
+		}
+	}
+	if = {
+	limit = {
+	FROM = { tier = DUKE }
+	check_variable = { which = "seduction_progress" value = 10 }
+	NOT = { check_variable = { which = "seduction_progress" value = 25 } }
+	}
+	location = {
+			ROOT = {
+				spawn_unit = {
+					province = PREV
+					troops = {
+						light_infantry = { 25 25 }
+						archers = {	25 25 }
+					}
+				}
+			}
+		}
+	}
+	if = {
+	limit = {
+	FROM = { tier = DUKE }
+	check_variable = { which = "seduction_progress" value = 1 }
+	NOT = { check_variable = { which = "seduction_progress" value = 10 } }
+	}
+	location = {
+			ROOT = {
+				spawn_unit = {
+					province = PREV
+					troops = {
+						light_infantry = { 15 15 }
+						archers = {	15 15 }
+					}
+				}
+			}
+		}
+	}
+
+	if = {
+	limit = {
+	FROM = { lower_tier_than = DUKE }
+	check_variable = { which = "seduction_progress" value = 50 }
+	}
+	location = {
+			ROOT = {
+				spawn_unit = {
+					province = PREV
+					troops = {
+						light_infantry = { 30 30 }
+						archers = {	15 15 }
+					}
+				}
+			}
+		}
+	}
+	if = {
+	limit = {
+	FROM = { lower_tier_than = DUKE }
+ 	check_variable = { which = "seduction_progress" value = 25 }
+	NOT = { check_variable = { which = "seduction_progress" value = 50 } }
+	}
+	location = {
+			ROOT = {
+				spawn_unit = {
+					province = PREV
+					troops = {
+						light_infantry = { 20 20 }
+						archers = {	10 10 }
+					}
+				}
+			}
+		}
+	}
+	if = {
+	limit = {
+	FROM = { lower_tier_than = DUKE }
+	check_variable = { which = "seduction_progress" value = 10 }
+	NOT = { check_variable = { which = "seduction_progress" value = 25 } }
+	}
+	location = {
+			ROOT = {
+				spawn_unit = {
+					province = PREV
+					troops = {
+						light_infantry = { 15 15 }
+						archers = {	10 10 }
+					}
+				}
+			}
+		}
+	}
+	if = {
+	limit = {
+	FROM = { lower_tier_than = DUKE }
+	check_variable = { which = "seduction_progress" value = 1 }
+	NOT = { check_variable = { which = "seduction_progress" value = 10 } }
+	}
+	location = {
+			ROOT = {
+				spawn_unit = {
+					province = PREV
+					troops = {
+						light_infantry = { 15 15 }
+					}
+				}
+			}
+		}
+	}
+
+	}
+
+	}
+
+
+	##target gets his reward
+	character_event = {
+	id = lahmia.58
+	title = LAHMIA_SEDUCTION
+	desc = lahmia58desc #Your dear lady friend is delighted, and you are richly rewarded for your generosity over the coming days and weeks. You are pleased with yourself, as the city would be such a dull place without her stunning beauty, lavish parties and clever wit. She really is the center of high society in many ways.
+	picture = "GFX_vampiress1"
+	hide_from = yes
+
+	is_triggered_only = yes
+
+	option = {
+	name = lahmia58A #I couldn't let such a noble lady be distraught
+	}
+
+	}
+
+	##target refuses to help with money, lahmia is informed
+	character_event = {
+	id = lahmia.59
+	title = LAHMIA_SEDUCTION
+	desc = lahmia59desc #Curses! Your target is apparently not so easily manipulated... he refuses to help you with troops, which makes him useless to you. All this work wasted... it is time to return home.
+	picture = "GFX_evt_cultist"
+	hide_from = yes
+
+	is_triggered_only = yes
+
+	option = {
+	name = lahmia59A #That arrogant mortal, I should rip his throat out...
+	remove_trait = on_lahmian_mission
+	clr_character_flag = damselindistress
+	clr_character_flag = lahmianbanquet
+	clr_character_flag = killed_wife_success
+	clr_character_flag = killed_wife_failure
+	clr_character_flag = lahmiancomfort
+	clr_character_flag = lahmia12failed
+	clr_character_flag = return_home_lahmia
+	set_variable = { which = "seduction_progress" value = 0 }
+	if = {
+	limit = {
+	NOT = { trait = lahmian_queen }
+	}
+	any_playable_ruler = {
+	limit = { trait = lahmian_queen }
+	character_event = { id = lahmia.100 } ##100 is the failure event that the queen gets
+	}
+	}
+	}
+
+	}
+
+	##target refuses to help with money, target is informed that heiress has left
+	character_event = {
+	id = lahmia.60
+	desc = lahmia60desc #You refuse to help out the heiress with troops, and despite her pleas, you leave the ball without helping her. The next day, you are informed that she has packed up and left the city.
+	picture = "GFX_evt_cultist"
+	hide_from = yes
+
+	is_triggered_only = yes
+
+	option = {
+	name = lahmia60A #A shame. I think I'll miss her.
+	}
+
+	}
+
+
+	##THE MAINTENANCE EVENTS##
+	##mission failure event, goes to the queen
+	character_event = {
+	id = lahmia.100
+	desc = lahmia100desc #My Queen, I have failed you. The target resisted attempts at seduction, and would be of no help in gaining us either gold or troops.
+	picture = "GFX_evt_cultist"
+
+	is_triggered_only = yes
+
+	option = {
+	trigger = { ai = no }
+	name = lahmia100A #Failure is not an option, my dear...
+	FROM = {
+		if = {
+ limit = {
+ is_invincible_trigger = yes
+ }
+
+			antideath_effect = yes
+			break = yes
+}
+	death = { death_reason = death_sacrificed }
+	}
+	}
+
+	option = {
+	name = lahmia100B #You disappoint me, dear daughter
+	FROM = {
+	prestige = -100
+	}
+	}
+
+	}
+
+	##mission failure event, target dead, goes to the queen
+	character_event = {
+	id = lahmia.101
+	desc = lahmia101desc #My Queen, the target has died. There is nothing more for me to do here... I shall return home immediately.
+	picture = "GFX_evt_cultist"
+
+	is_triggered_only = yes
+
+	option = {
+	name = lahmia101A #These mortals... such brief lives...
+	}
+
+	}
+
+	##queen is told that gold has been sent
+	character_event = {
+	id = lahmia.102
+	desc = lahmia102desc #My Queen, I send you these gifts. I succeeded in manipulating my target into giving me some gold to maintain my lifestyle.
+	picture = "GFX_evt_cultist"
+
+	is_triggered_only = yes
+
+	option = {
+	name = lahmia102A #Well done, daughter.
+	FROM = {
+	prestige = 50
+	piety = 50
+	}
+	}
+
+	option = {
+	name = lahmia102B #Well done, daughter. Return home when you are able.
+	trigger = { ai = no }
+	FROM = {
+	prestige = 50
+	piety = 50
+	set_character_flag = return_home_lahmia
+	}
+	}
+	}
+
+	##queen is told that gold has been sent
+	character_event = {
+	id = lahmia.103
+	desc = lahmia103desc #My Queen, I send you these troops. I succeeded in manipulating my target into giving me some to protect my dear elderly relative... I trust you will soon have them turned into loyal servants of the sisterhood shortly after they arrive.
+	picture = "GFX_evt_cultist"
+
+	is_triggered_only = yes
+
+	option = {
+	name = lahmia103A #Well done, daughter. We look forward to breaking them in.
+	FROM = {
+	prestige = 50
+	piety = 50
+	}
+	}
+
+	option = {
+	name = lahmia103B #Well done, daughter. Return home when you are able.
+	trigger = { ai = no }
+	FROM = {
+	prestige = 50
+	piety = 50
+	set_character_flag = return_home_lahmia
+	}
+	}
+	}
+
+	##LAHMIA 104-106 USED ABOVE###
+
+
+	###Events to bring an unlanded lover to your court, very useful if they have a claim
+
+	#Targets get the offer to join Lahmian Queens Court
+	character_event = {
+	id = lahmia.200
+	desc = lahmia200desc #One night alone with you lover she smiles darkly at you, revealing sharp fangs, and grasps you with supernatural strength preventing you from running. She is a vampire! She wants you to come with her to the Lahmian Court, where you may be granted life eternal, and great power... do you dare refuse?
+	picture = "GFX_vampiress1"
+
+	is_triggered_only = yes
+
+	option = {
+	name = lahmia200A #I'll never join the Lahmians!
+ai_chance = {
+      factor = 50
+
+	modifier = {
+         factor = 2.0
+         is_primary_heir = yes
+      }
+
+	modifier = {
+         factor = 4.0
+		 OR = {
+		 mother = { tier = EMPEROR }
+         father = { tier = EMPEROR }
+		 }
+      }
+
+	modifier = {
+         factor = 2.0
+		 OR = {
+		 mother = { tier = KING }
+         father = { tier = KING }
+		 }
+      }
+
+	modifier = {
+         factor = 1.5
+		 OR = {
+		 mother = { tier = DUKE }
+         father = { tier = DUKE }
+		 }
+      }
+
+    modifier = {
+         factor = 2.0
+         trait = proud
+      }
+    modifier = {
+         factor = 2.0
+         trait = zealous
+      }
+    modifier = {
+         factor = 2.0
+         trait = wroth
+      }
+    modifier = {
+         factor = 4.0
+         trait = content
+      }
+    modifier = {
+         factor = 2.0
+         FROMFROM = { intrigue = 10 }
+      }
+    modifier = {
+         factor = 2.0
+         FROMFROM = { intrigue = 15 }
+      }
+    modifier = {
+         factor = 2.0
+         FROMFROM = { intrigue = 20 }
+      }
+    modifier = {
+         factor = 2.0
+         FROMFROM = { intrigue = 25 }
+      }
+    modifier = {
+         factor = 1.5
+         FROMFROM = { trait = fair }
+      }
+    modifier = {
+         factor = 2.0
+         FROMFROM = { trait = pretty }
+      }
+    modifier = {
+         factor = 3.0
+         FROMFROM = { trait = beautiful }
+      }
+}
+	remove_lover = FROMFROM
+	FROMFROM = { long_character_event = { id = lahmia.203 days = 1 } }
+	}
+
+	option = {
+	name = lahmia200B #Eternal life and power you say? Why of course, lover...
+ai_chance = {
+      factor = 50
+
+      modifier = {
+         factor = 2.0
+         trait = craven
+      }
+      modifier = {
+         factor = 4.0
+         trait = lustful
+      }
+      modifier = {
+         factor = 4.0
+         trait = hedonist
+      }
+      modifier = {
+         factor = 2.0
+         trait = ambitious
+      }
+      modifier = {
+         factor = 2.0
+         FROMFROM = { intrigue = 10 }
+      }
+      modifier = {
+         factor = 2.0
+         FROMFROM = { intrigue = 15 }
+      }
+      modifier = {
+         factor = 2.0
+         FROMFROM = { intrigue = 20 }
+      }
+      modifier = {
+         factor = 2.0
+         FROMFROM = { intrigue = 25 }
+      }
+      modifier = {
+         factor = 1.5
+         FROMFROM = { trait = fair }
+      }
+      modifier = {
+         factor = 2.0
+         FROMFROM = { trait = pretty }
+      }
+      modifier = {
+         factor = 3.0
+         FROMFROM = { trait = beautiful }
+      }
+}
+	FROMFROM = { long_character_event = { id = lahmia.202 days = 1 } }
+	religion = vampiric
+	add_trait = disinherited
+	recalc_succession = yes
+	}
+	}
+
+	#Success at making lover move to lahmian court, vampire is informed
+	long_character_event = {
+	id = lahmia.202
+	desc = lahmia202desc #One night alone with your mortal plaything you smile darkly at jim, revealing sharp fangs, and grasp him with supernatural strength preventing him from running. You ask him to join you at the Lahmian Court, where he may be granted life eternal, and great power... after a brief hesitation once the shock subsides, you see that he will do as instructed. The promise of power and an eternity of delights has swayed his weak mind, and you can now do with him as you wish. He is disinherited from his family forever now, but if he has any claims, you can press them forcefully in war if you so desire.
+	picture = "GFX_vampiress1"
+
+	is_triggered_only = yes
+
+	option = {
+	name = lahmia202A #Excellent...
+	reverse_banish = FROM
+	}
+
+	}
+
+	long_character_event = {
+	id = lahmia.203
+	desc = lahmia203desc #One night alone with your mortal plaything you smile darkly at him, revealing sharp fangs, and grasp him with supernatural strength preventing him from running. You ask him to join you at the Lahmian Court, where he may be granted life eternal, and great power... after a brief hesitation once the shock subsides, you see that he will not do as instructed. He tries to pull away from you and screams for the guards - what do you do?
+	picture = "GFX_vampiress1"
+
+	is_triggered_only = yes
+
+	option = {
+	name = lahmia203A #Attack him!
+	trigger = { ai = no }
+	FROM = { character_event = {id = duelengine.1 days = 1} }
+	}
+
+	option = {
+	name = lahmia203B #*hiss* Weak fool! (Jump out the window and make a run for it)
+	}
+	}
+
+
+	##Events where you send out a dynasty member to recruit new lahmians##
+
+	character_event = {
+	id = lahmia.204
+	desc = lahmia204desc #You think you have found a mark... she is reputedly both beautiful and highly skilled in the arts of intrigue. She might make a fine addition to the sisterhood. Shall you seek her out?
+	picture = "GFX_evt_cultist"
+
+	is_triggered_only = yes #bi annual pulse
+
+	trigger = {
+	age = 1
+	trait = on_lahmian_mission
+	has_character_flag = recruitment_mission
+	}
+
+	option = {
+	name = lahmia204A #Yes, by all means
+	random_playable_ruler = {
+	limit = {
+	any_courtier = {
+	is_landed = no
+	is_female = yes
+	trait = creature_human
+	age = 16
+	NOT = { age = 25 }
+	intrigue = 10
+	NOT = { trait = vampire_lahmian_visible }
+	NOT = { trait = vampire_carstein_visible }
+	NOT = { trait = vampire_blood_visible }
+	NOT = { trait = vampire_strigoi_visible }
+	NOT = { trait = vampire_necrarch_visible }
+	NOT = { trait = vampire_jade_visible }
+	NOT = { trait = vampire_mahtmasi_visible }
+	OR = {
+	trait = pretty
+	trait = fair
+	trait = beautiful
+	}
+	}
+	}
+	random_courtier = {
+	limit = {
+	is_landed = no
+	is_female = yes
+	trait = creature_human
+	age = 16
+	NOT = { age = 25 }
+	intrigue = 10
+	NOT = { trait = vampire_lahmian_visible }
+	NOT = { trait = vampire_carstein_visible }
+	NOT = { trait = vampire_blood_visible }
+	NOT = { trait = vampire_strigoi_visible }
+	NOT = { trait = vampire_necrarch_visible }
+	NOT = { trait = vampire_jade_visible }
+	NOT = { trait = vampire_mahtmasi_visible }
+	OR = {
+	trait = pretty
+	trait = fair
+	trait = beautiful
+	}
+	}
+	character_event = { id = lahmia.205 }
+	}
+	}
+	}
+	}
+
+
+	character_event = {
+	id = lahmia.205
+	desc = lahmia205desc #doesnt really matter, only for unlanded AIs. But she gets the offer to join the lahmians, thats the gist
+	picture = "GFX_vampiress1"
+
+	is_triggered_only = yes
+
+	option = {
+	name = lahmia205A #Yes
+ai_chance = {
+      factor = 50
+
+      modifier = {
+         factor = 2.0
+         trait = craven
+      }
+      modifier = {
+         factor = 4.0
+         trait = lustful
+      }
+      modifier = {
+         factor = 4.0
+         trait = hedonist
+      }
+      modifier = {
+         factor = 2.0
+         trait = ambitious
+      }
+      modifier = {
+         factor = 2.0
+         FROM = { intrigue = 10 }
+      }
+      modifier = {
+         factor = 2.0
+         FROM = { intrigue = 15 }
+      }
+      modifier = {
+         factor = 2.0
+         FROM = { intrigue = 20 }
+      }
+      modifier = {
+         factor = 2.0
+         FROM = { intrigue = 25 }
+      }
+      modifier = {
+         factor = 1.5
+         FROM = { trait = fair }
+      }
+      modifier = {
+         factor = 2.0
+         FROM = { trait = pretty }
+      }
+      modifier = {
+         factor = 3.0
+         FROM = { trait = beautiful }
+      }
+}
+FROM = { character_event = { id = lahmia.206 } }
+add_trait = disinherited
+any_sibling = { character_event = { id = lahmia.208 days = 1 } } #family is informed
+father = { character_event = { id = lahmia.208 days = 1 } }
+mother = { character_event = { id = lahmia.208 days = 1 } }
+prestige = 25
+if = {
+limit = {
+is_married = yes
+}
+spouse = {
+character_event = { id = lahmia.209 } #husband is informed his wife has left him to become a vampire hooker
+}
+}
+}
+
+	option = {
+	name = lahmia205B #No
+ai_chance = {
+      factor = 50
+
+	modifier = {
+         factor = 2.0
+         is_primary_heir = yes
+      }
+
+	modifier = {
+         factor = 4.0
+		 OR = {
+		 mother = { tier = EMPEROR }
+         father = { tier = EMPEROR }
+		 }
+      }
+
+	modifier = {
+         factor = 2.0
+		 OR = {
+		 mother = { tier = KING }
+         father = { tier = KING }
+		 }
+      }
+
+	modifier = {
+         factor = 1.5
+		 OR = {
+		 mother = { tier = DUKE }
+         father = { tier = DUKE }
+		 }
+      }
+
+    modifier = {
+         factor = 2.0
+         trait = proud
+      }
+    modifier = {
+         factor = 2.0
+         trait = zealous
+      }
+    modifier = {
+         factor = 2.0
+         trait = wroth
+      }
+    modifier = {
+         factor = 4.0
+         trait = content
+      }
+    modifier = {
+         factor = 2.0
+         FROM = { intrigue = 10 }
+      }
+    modifier = {
+         factor = 2.0
+         FROM = { intrigue = 15 }
+      }
+    modifier = {
+         factor = 2.0
+         FROM = { intrigue = 20 }
+      }
+    modifier = {
+         factor = 2.0
+         FROM = { intrigue = 25 }
+      }
+    modifier = {
+         factor = 1.5
+         FROM = { trait = fair }
+      }
+    modifier = {
+         factor = 2.0
+         FROM = { trait = pretty }
+      }
+    modifier = {
+         factor = 3.0
+         FROM = { trait = beautiful }
+      }
+}
+FROM = { character_event = { id = lahmia.207 } }
+	}
+
+	}
+
+	#Success, Lahmian Agents point of view
+	character_event = {
+	id = lahmia.206
+	desc = lahmia206desc #Through a mixture of seduction, intimidation, and just-perfectly set up circumstances, you convince your mark to accept the blood kiss and join the Lahmian sisterhood. Your queen will be very pleased...
+	picture = "GFX_vampiress1"
+
+	is_triggered_only = yes
+
+	option = {
+	name = EXCELLENT
+	prestige = 25
+	if = {
+	limit = {
+	NOT = { intrigue = 30 }
+	}
+	random_list = {
+	95 = { }
+	5 = { change_intrigue = 1 }
+	}
+	}
+	FROM = { add_trait = vampire_lahmian_visible
+		set_graphical_culture = lahmian_vampire
+					set_variable = { which = khornefavor value = 0 }
+					set_variable = { which = nurglefavor value = 0 }
+					set_variable = { which = slaaneshfavor value = 0 }
+					set_variable = { which = tzeentchfavor value = 0 }
+					set_variable = { which = "khorne_favor" value = 0 }
+					set_variable = { which = "nurgle_favor" value = 0 }
+					set_variable = { which = "slaanesh_favor" value = 0 }
+					set_variable = { which = "tzeentch_favor" value = 0 }
+					clr_character_flag = hidden_tzeentch_cultist3
+					clr_character_flag = hidden_tzeentch_cultist2
+					clr_character_flag = hidden_tzeentch_cultist
+					clr_character_flag = hidden_nurgle_cultist3
+					clr_character_flag = hidden_nurgle_cultist2
+					clr_character_flag = hidden_nurgle_cultist
+					clr_character_flag = hidden_khorne_cultist3
+					clr_character_flag = hidden_khorne_cultist2
+					clr_character_flag = hidden_khorne_cultist
+					clr_character_flag = hidden_slaanesh_cultist3
+					clr_character_flag = hidden_slaanesh_cultist2
+					clr_character_flag = hidden_slaanesh_cultist
+					clr_character_flag = hidden_undivided_cultist3
+					clr_character_flag = hidden_undivided_cultist2
+					clr_character_flag = hidden_undivided_cultist }
+	FROM = { recalc_succession = yes }
+	FROM = { religion = vampiric }
+	if = {
+	limit = { is_female = no }
+	FROM = { dynasty = ROOT }
+	FROM = { set_father = ROOT }
+	}
+	if = {
+	limit = { is_female = yes }
+	FROM = { dynasty = ROOT }
+	FROM = { set_mother = ROOT }
+	}
+	if = {
+	limit = {
+	NOT = { trait = lahmian_queen }
+	}
+	any_playable_ruler = {
+	limit = { trait = lahmian_queen }
+	character_event = { id = lahmia.210 }
+	}
+	}
+	}
+
+	}
+
+
+	character_event = {
+	id = lahmia.207
+	desc = lahmia207desc
+	picture = "GFX_vampiress1"
+
+	is_triggered_only = yes
+
+	option = {
+	name = lahmia207A
+	trigger = { age = 1 }
+		}
+
+		}
+
+
+	#close family is informed she has run off
+	character_event = {
+	id = lahmia.208
+	desc = lahmia208desc #Your [GetFromRelation] has run off it seems, leaving her home and family. Why would she do something like this, what could have possibly enticed her to give up everything she had?
+	picture = "GFX_evt_cultist"
+
+	is_triggered_only = yes
+
+	option = {
+	name = lahmia208A #Scandalous... she is cut off!
+	trigger = { is_female = no }
+	}
+
+	option = {
+	name = lahmia208B #Poor girl, she had so much potential.
+	trigger = { is_female = yes }
+	}
+	}
+
+	character_event = {
+	id = lahmia.209
+	desc = lahmia209desc
+	picture = "GFX_evt_marriage"
+
+	is_triggered_only = yes
+
+	option = {
+	name = lahmia209A
+	trigger = { age = 1 }
+	remove_spouse = FROM
+	}
+
+	}
+
+
+
+	#queen is informed of success
+	character_event = {
+	id = lahmia.210
+	desc = lahmia210desc #My Queen, I have sired a new Lahmian progeny. She is both beautiful and highly skilled. I trust that she will make us proud, and serve the sisterhood well.
+	picture = "GFX_vampiress1"
+
+	is_triggered_only = yes
+
+	option = {
+	name = lahmia210A #Well done. You are a good minion.
+	reverse_banish = FROMFROM
+	FROM = { prestige = 25 }
+	FROM = { piety = 25 }
+	}
+
+	}
+
+	###Now for the events to make a "Lahmian Presence" province modifer which interacts with the witch hunter system and lahmian defenders##
+
+	#mark gets hidden event setting up the province modifier lahmian_presence
+	character_event = {
+	id = lahmia.300
+	desc = lahmia210desc #hidden, but lahmian presence is established
+	picture = "GFX_vampiress1"
+	hide_window = yes
+
+	is_triggered_only = yes
+
+	option = {
+	name = lahmia210A #hidden
+	random_demesne_province = {
+	add_province_modifier = { name = lahmian_presence duration = -1 }
+	}
+	}
+
+	}
+
+	##every year or so, provinces with the modifier send gold to lahmian queen#
+	province_event = {
+	id = lahmia.301
+	desc = lahmia210desc #hidden
+	picture = GFX_evt_council
+	hide_window = yes
+
+	trigger = {
+	religion_group = old_world_group
+	has_province_modifier = lahmian_presence
+	}
+
+	mean_time_to_happen = {
+	days = 365
+	}
+	option = {
+     name = OK
+     trigger = {
+       NOT = {
+         has_global_flag = lahmia302
+       }
+     }
+
+     any_playable_ruler = {
+       limit = {
+         trait = lahmian_queen
+       }
+
+     character_event = { id = lahmia.302 }
+     }
+   }
+
+   option = {
+     name = OK
+     trigger = {
+       has_global_flag = lahmia302
+     }
+
+     any_playable_ruler = {
+       limit = {
+         trait = lahmian_queen
+       }
+
+       random_list = {
+         33 = { wealth = 10 }
+         33 = { wealth = 20}
+         33 = { wealth = 30 }
+       }
+     }
+   }
+}
+
+	#lahmian queen gets money from her holdings abroad
+	character_event = {
+	id = lahmia.302
+	desc = lahmia302desc #One of your holdings in the realms of men has sent you their bi-annual profits. Whether from prostitution, blackmail, assassinations or simple corrupt business deals, they have managed to turn a tidy profit it seems.
+	picture = "GFX_evt_brothel"
+
+	is_triggered_only = yes
+
+	option = {
+	name = lahmia302A #Well done, sisters.
+	random_list = {
+	33 = { wealth = 10 }
+	33 = { wealth = 20}
+	33 = { wealth = 30 }
+	}
+	}
+
+	option = {
+	name = lahmia302B #Do not bother me with this again. Just send the cash.
+	set_global_flag = lahmia302
+	random_list = {
+	33 = { wealth = 10 }
+	33 = { wealth = 20}
+	33 = { wealth = 30 }
+	}
+	}
+	}
+
+	##witch hunters randomly seek out lahmian_presence infestations, and are then met in personal combat by the lahmian protectors. Witch hunter spots a cabal, and investigates:
+	character_event = {
+	id = lahmia.303
+	desc = lahmia303desc #There have been strange goings-on in this province. The temple suspects a hidden group of vampires, and these must be rooted out with fire and sword.
+	picture = "GFX_evt_brothel"
+	min_age = 16
+
+	is_triggered_only = yes #random yearly pulse
+
+	trigger = {
+	trait = witch_hunter
+	NOT = { trait = on_witch_hunt }
+	any_realm_province = { has_province_modifier = lahmian_presence }
+	learning = 10
+	NOT = { has_character_flag = duel }
+	}
+
+
+	option = {
+	name = lahmia303A #Our faith will prevail!
+
+	save_event_target_as = duelist_a
+	set_character_flag = duel
+	character_event = { id = lahmia.304 days = 60 } #if the witch hunter is alive, he has won the duel survived to warn the authorities, and the lahmian presence is destroyed
+	random_playable_ruler = {
+	limit = {
+	any_courtier = { has_minor_title = lahmian_protector}
+	}
+	random_courtier = {
+	limit = { has_minor_title = lahmian_protector }
+	save_event_target_as = duelist_b
+	character_event = { id = duelengine.1 days = 1}
+	prestige = 25 #if he wins, he gets a litlte prestige each time
+	}
+	}
+	}
+
+	option = {
+	name = lahmia303B #No, it s probably nothing...
+	trigger = {
+	OR = {
+	trait = craven
+	trait = arbitrary
+	trait = content
+	}
+	}
+	prestige = -20
+	}
+}
+
+	#if witch hunter has survived, he warns the authorities and the holding is destroyed
+	character_event = {
+	id = lahmia.304
+	desc = lahmia304desc #You have survived the efforts of the vampires to stop you, and now that you know they are here, the infestation is rooted out with fire, stakes, and cold silver.
+	picture = "GFX_evt_brothel"
+
+	is_triggered_only = yes
+
+	option = {
+	name = lahmia304A #Our faith prevails again!
+	random_realm_province = {
+	remove_province_modifier = lahmian_presence
+	}
+	any_playable_ruler = {
+	limit = {
+	trait = lahmian_queen
+	NOT = { has_character_flag = lahmia305 }
+	}
+	character_event = { id = lahmia.305 }
+	}
+	}
+
+	}
+
+	#lahmian queen is informed her holding has been destroyed#
+	character_event = {
+	id = lahmia.305
+	desc = lahmia305desc #One of your holdings has been destroyed by the Witch Hunters. Perhaps it is time to appoint some better Protectors? It is their job to prevent these things from happening!
+	picture = "GFX_evt_burning_house"
+
+	is_triggered_only = yes
+
+	option = {
+	name = lahmia305A #Curses!
+	}
+
+	option = {
+	name = lahmia305B #Do not bother me with such bad news again!
+	set_character_flag = lahmia305
+	}
+}
+# Liege: fund expedition?
+character_event = {
+	id = lahmia.395
+	desc = EVTDESC_cleanse_nehekharan_curse_marshal_liege
+	picture = GFX_evt_mage_lore_necromancy
+	border = GFX_event_normal_frame_war
+	
+	is_triggered_only = yes
+	
+	option = {
+		name = EVTOPTA_cleanse_nehekharan_curse_marshal_liege
+			wealth = -200
+			piety = -50
+			prestige = 100
+			hidden_tooltip = { 
+					character_event = { id = lahmia.396 days = 25 } 
+			} 
+		ai_chance = { factor = 1 }
+
+	}
+	option = {
+		name = EVTOPTB_cleanse_nehekharan_curse_marshal_liege
+		prestige = -50
+		piety = 5
+		ai_chance = { factor = 0 }
+
+	}
+}
+# Liege: success
+character_event = {
+	id = lahmia.396
+	desc = EVTDESC_cleanse_nehekharan_curse_success
+	picture = GFX_evt_necromancy
+	border = GFX_event_normal_frame_war
+	
+	is_triggered_only = yes
+	
+	option = {
+		name = EVTOPTA_cleanse_nehekharan_curse_success
+			hidden_tooltip = { 
+			FROMFROM = { location = { remove_province_modifier = nehekharan_curse } }
+			FROMFROM = { location = { remove_province_modifier = incapacitated_tomb_king } }
+			FROMFROM = { location = { set_province_flag = removed_curse_nehekharan } }
+			FROMFROM = { refill_holding_levy = yes }
+				if = { limit = { 
+							NOR = { 
+								trait = creature_nehekharan 
+								culture = blooddragons_culture
+								culture = witchhunter_culture
+								culture = living_jade
+							}
+							FROMFROM = {
+								OR = {
+									location = { culture_group = nehekharan_group } 
+								}
+							} } 
+							FROMFROM = { location = { religion = ROOT
+										culture = ROOT } } 
+						}
+					} 
+			hidden_tooltip = { if = { limit = { trait = creature_nehekharan
+							FROMFROM = {
+								OR = {
+									location = { culture_group = nehekharan_group } 
+								}
+							} } 
+							FROMFROM = { 
+								location = {
+									culture = nehekka 
+									religion = atruhayid
+								}
+							} 
+						}
+					}
+			hidden_tooltip = { if = { limit = { culture = living_jade
+							FROMFROM = {
+								OR = {
+									location = { culture_group = nehekharan_group } 
+								}
+							} } 
+							FROMFROM = { 
+								location = {
+									culture = lizardman_lost
+									religion = vampiric
+								}
+							} 
+						}
+					}
+				hidden_tooltip = { 
+					if = { 
+							limit = { 
+								culture = blooddragons_culture
+								FROMFROM = {
+									OR = {
+									location = { culture_group = nehekharan_group } 
+									}
+								} 
+							}
+							if = {
+								limit = {
+									FROMFROM = {
+										location = { region = world_old_world_empire } 
+									}
+								}
+								FROMFROM = { 
+									location = {
+										culture = reiklander 
+										religion = ROOT
+									}
+								} 
+							}
+							if = {
+								limit = {
+									FROMFROM = {
+										location = { region = world_old_world_border_princes } 
+									}
+								}
+								FROMFROM = { 
+									location = {
+										culture = neueslander 
+										religion = ROOT
+									}
+								} 
+							}
+							if = {
+								limit = {
+									FROMFROM = {
+										location = { region = world_old_world_kislev } 
+									}
+								}
+								FROMFROM = { 
+									location = {
+										culture = kislevite 
+										religion = ROOT
+									}
+								} 
+							}
+							if = {
+								limit = {
+									FROMFROM = {
+										location = { region = world_old_world_bretonnia } 
+									}
+								}
+								FROMFROM = { 
+									location = {
+										culture = nortagnese 
+										religion = ROOT
+									}
+								} 
+							}
+							if = {
+								limit = {
+									FROMFROM = {
+										location = { region = world_old_world_estalia } 
+									}
+								}
+								FROMFROM = { 
+									location = {
+										culture = astur 
+										religion = ROOT
+									}
+								} 
+							}
+							if = {
+								limit = {
+									FROMFROM = {
+										location = { region = world_old_world_tilea } 
+									}
+								}
+								FROMFROM = { 
+									location = {
+										culture = reman 
+										religion = ROOT
+									}
+								} 
+							}
+							if = {
+								limit = {
+									FROMFROM = {
+										location = { region = world_badlands_strygos } 
+									}
+								}
+								FROMFROM = { 
+									location = {
+										culture = strigany 
+										religion = ROOT
+									}
+								} 
+							}
+							if = {
+								limit = {
+									FROMFROM = {
+										location = { region = world_badlands_magnata } 
+									}
+								}
+								FROMFROM = { 
+									location = {
+										culture = myken 
+										religion = ROOT
+									}
+								} 
+							}
+							if = {
+								limit = {
+									FROMFROM = {
+										location = { region = world_greater_araby_araby } 
+									}
+								}
+								FROMFROM = { 
+									location = {
+										culture = ramaccan 
+										religion = ROOT
+									}
+								} 
+							}
+							if = {
+								limit = {
+									FROMFROM = {
+										location = { region = world_greater_araby_southlands } 
+									}
+								}
+								FROMFROM = { 
+									location = {
+										culture = wasai 
+										religion = ROOT
+									}
+								} 
+							}
+							if = {
+								limit = {
+									FROMFROM = {
+										location = { region = world_nehekhara } 
+									}
+								}
+								FROMFROM = { 
+									location = {
+										culture = nehekka 
+										religion = ROOT
+									}
+								} 
+							}
+							if = {
+								limit = {
+									FROMFROM = {
+										location = { region = world_norsca } 
+									}
+								}
+								FROMFROM = { 
+									location = {
+										culture = aesling 
+										religion = ROOT
+									}
+								} 
+							}
+							if = {
+								limit = {
+									FROMFROM = {
+										location = { region = world_karaz_ankor } 
+									}
+								}
+								FROMFROM = { 
+									location = {
+										culture = strigany 
+										religion = ROOT
+									}
+								} 
+							}
+							if = {
+								limit = {
+									FROMFROM = {
+										location = { region = world_darklands_plains_of_bones } 
+									}
+								}
+								FROMFROM = { 
+									location = {
+										culture = strigany 
+										religion = ROOT
+									}
+								} 
+							}
+							if = {
+								limit = {
+									FROMFROM = {
+										location = { region = world_darklands_ankor_naggrund } 
+									}
+								}
+								FROMFROM = { 
+									location = {
+										culture = strigany 
+										religion = ROOT
+									}
+								} 
+							}
+							if = {
+								limit = {
+									FROMFROM = {
+										location = { region = world_darklands_blasted_wastes } 
+									}
+								}
+								FROMFROM = { 
+									location = {
+										culture = strigany 
+										religion = ROOT
+									}
+								} 
+							}
+							if = {
+								limit = {
+									FROMFROM = {
+										location = { region = world_drak_ankor } 
+									}
+								}
+								FROMFROM = { 
+									location = {
+										culture = strigany 
+										religion = ROOT
+									}
+								} 
+							}
+							if = {
+								limit = {
+									FROMFROM = {
+										location = { region = world_ulthuan } 
+									}
+								}
+								FROMFROM = { 
+									location = {
+										culture = strigany 
+										religion = ROOT
+									}
+								} 
+							}
+							if = {
+								limit = {
+									FROMFROM = {
+										location = { region = world_new_world_lustria } 
+									}
+								}
+								FROMFROM = { 
+									location = {
+										culture = strigany 
+										religion = ROOT
+									}
+								} 
+							}
+							if = {
+								limit = {
+									FROMFROM = {
+										location = { region = world_new_world_arnheim } 
+									}
+								}
+								FROMFROM = { 
+									location = {
+										culture = strigany 
+										religion = ROOT
+									}
+								} 
+							}
+							if = {
+								limit = {
+									FROMFROM = {
+										location = { region = world_new_world_naggaroth } 
+									}
+								}
+								FROMFROM = { 
+									location = {
+										culture = strigany 
+										religion = ROOT
+									}
+								} 
+							}
+							if = {
+								limit = {
+									FROMFROM = {
+										location = { region = world_dragon_isles } 
+									}
+								}
+								FROMFROM = { 
+									location = {
+										culture = strigany 
+										religion = ROOT
+									}
+								} 
+							}
+							if = {
+								limit = {
+									FROMFROM = {
+										location = { region = world_athel_loren } 
+									}
+								}
+								FROMFROM = { 
+									location = {
+										culture = strigany 
+										religion = ROOT
+									}
+								} 
+							}
+							if = {
+								limit = {
+									FROMFROM = {
+										location = { region = world_chaos_wastes } 
+									}
+								}
+								FROMFROM = { 
+									location = {
+										culture = kul 
+										religion = ROOT
+									}
+								} 
+							}
+						}
+				} 
+				hidden_tooltip = { 
+					if = { 
+							limit = { 
+								culture = witchhunter_culture
+								FROMFROM = {
+									OR = {
+									location = { culture_group = nehekharan_group } 
+									}
+								} 
+							}
+							if = {
+								limit = {
+									FROMFROM = {
+										location = { region = world_old_world_empire } 
+									}
+								}
+								FROMFROM = { 
+									location = {
+										culture = reiklander 
+										religion = ROOT
+									}
+								} 
+							}
+							if = {
+								limit = {
+									FROMFROM = {
+										location = { region = world_old_world_border_princes } 
+									}
+								}
+								FROMFROM = { 
+									location = {
+										culture = neueslander 
+										religion = ROOT
+									}
+								} 
+							}
+							if = {
+								limit = {
+									FROMFROM = {
+										location = { region = world_old_world_kislev } 
+									}
+								}
+								FROMFROM = { 
+									location = {
+										culture = kislevite 
+										religion = ROOT
+									}
+								} 
+							}
+							if = {
+								limit = {
+									FROMFROM = {
+										location = { region = world_old_world_bretonnia } 
+									}
+								}
+								FROMFROM = { 
+									location = {
+										culture = nortagnese 
+										religion = ROOT
+									}
+								} 
+							}
+							if = {
+								limit = {
+									FROMFROM = {
+										location = { region = world_old_world_estalia } 
+									}
+								}
+								FROMFROM = { 
+									location = {
+										culture = astur 
+										religion = ROOT
+									}
+								} 
+							}
+							if = {
+								limit = {
+									FROMFROM = {
+										location = { region = world_old_world_tilea } 
+									}
+								}
+								FROMFROM = { 
+									location = {
+										culture = reman 
+										religion = ROOT
+									}
+								} 
+							}
+							if = {
+								limit = {
+									FROMFROM = {
+										location = { region = world_badlands_strygos } 
+									}
+								}
+								FROMFROM = { 
+									location = {
+										culture = strigany 
+										religion = ROOT
+									}
+								} 
+							}
+							if = {
+								limit = {
+									FROMFROM = {
+										location = { region = world_badlands_magnata } 
+									}
+								}
+								FROMFROM = { 
+									location = {
+										culture = myken 
+										religion = ROOT
+									}
+								} 
+							}
+							if = {
+								limit = {
+									FROMFROM = {
+										location = { region = world_greater_araby_araby } 
+									}
+								}
+								FROMFROM = { 
+									location = {
+										culture = ramaccan 
+										religion = ROOT
+									}
+								} 
+							}
+							if = {
+								limit = {
+									FROMFROM = {
+										location = { region = world_greater_araby_southlands } 
+									}
+								}
+								FROMFROM = { 
+									location = {
+										culture = wasai 
+										religion = ROOT
+									}
+								} 
+							}
+							if = {
+								limit = {
+									FROMFROM = {
+										location = { region = world_nehekhara } 
+									}
+								}
+								FROMFROM = { 
+									location = {
+										culture = nehekka 
+										religion = ROOT
+									}
+								} 
+							}
+							if = {
+								limit = {
+									FROMFROM = {
+										location = { region = world_norsca } 
+									}
+								}
+								FROMFROM = { 
+									location = {
+										culture = aesling 
+										religion = ROOT
+									}
+								} 
+							}
+							if = {
+								limit = {
+									FROMFROM = {
+										location = { region = world_karaz_ankor } 
+									}
+								}
+								FROMFROM = { 
+									location = {
+										culture = reiklander 
+										religion = ROOT
+									}
+								} 
+							}
+							if = {
+								limit = {
+									FROMFROM = {
+										location = { region = world_darklands_plains_of_bones } 
+									}
+								}
+								FROMFROM = { 
+									location = {
+										culture = reiklander 
+										religion = ROOT
+									}
+								} 
+							}
+							if = {
+								limit = {
+									FROMFROM = {
+										location = { region = world_darklands_ankor_naggrund } 
+									}
+								}
+								FROMFROM = { 
+									location = {
+										culture = reiklander 
+										religion = ROOT
+									}
+								} 
+							}
+							if = {
+								limit = {
+									FROMFROM = {
+										location = { region = world_darklands_blasted_wastes } 
+									}
+								}
+								FROMFROM = { 
+									location = {
+										culture = reiklander 
+										religion = ROOT
+									}
+								} 
+							}
+							if = {
+								limit = {
+									FROMFROM = {
+										location = { region = world_drak_ankor } 
+									}
+								}
+								FROMFROM = { 
+									location = {
+										culture = reiklander 
+										religion = ROOT
+									}
+								} 
+							}
+							if = {
+								limit = {
+									FROMFROM = {
+										location = { region = world_ulthuan } 
+									}
+								}
+								FROMFROM = { 
+									location = {
+										culture = reiklander 
+										religion = ROOT
+									}
+								} 
+							}
+							if = {
+								limit = {
+									FROMFROM = {
+										location = { region = world_new_world_lustria } 
+									}
+								}
+								FROMFROM = { 
+									location = {
+										culture = reiklander 
+										religion = ROOT
+									}
+								} 
+							}
+							if = {
+								limit = {
+									FROMFROM = {
+										location = { region = world_new_world_arnheim } 
+									}
+								}
+								FROMFROM = { 
+									location = {
+										culture = reiklander 
+										religion = ROOT
+									}
+								} 
+							}
+							if = {
+								limit = {
+									FROMFROM = {
+										location = { region = world_new_world_naggaroth } 
+									}
+								}
+								FROMFROM = { 
+									location = {
+										culture = reiklander 
+										religion = ROOT
+									}
+								} 
+							}
+							if = {
+								limit = {
+									FROMFROM = {
+										location = { region = world_dragon_isles } 
+									}
+								}
+								FROMFROM = { 
+									location = {
+										culture = reiklander 
+										religion = ROOT
+									}
+								} 
+							}
+							if = {
+								limit = {
+									FROMFROM = {
+										location = { region = world_athel_loren } 
+									}
+								}
+								FROMFROM = { 
+									location = {
+										culture = reiklander 
+										religion = ROOT
+									}
+								} 
+							}
+							if = {
+								limit = {
+									FROMFROM = {
+										location = { region = world_chaos_wastes } 
+									}
+								}
+								FROMFROM = { 
+									location = {
+										culture = kul 
+										religion = ROOT
+									}
+								} 
+							}
+						}
+				} 
+			hidden_tooltip = { if = { limit = { trait = creature_nehekharan
+							FROMFROM = {
+								OR = {
+									location = { culture_group = nehekharan_group } 
+								}
+							} } 
+							FROMFROM = { 
+								location = {
+									culture = nehekka 
+									religion = atruhayid
+								}
+							} 
+						}
+					} 					
+		ai_chance = { factor = 1 }
+	}
+}
+	##owner of province sometimes gets informed about activities related to the lahmian presence#
+	#Reserve IDs 320-350
+
+	##LAHMIAN FEAR FACTOR SYSTEM##
+
+
+
+	##Lahmian Blood Feast events, opinion bonus from vassals, increases revolt risk in province greatly

--- a/common/event_modifiers/warhammer_modifiers.txt
+++ b/common/event_modifiers/warhammer_modifiers.txt
@@ -1760,3 +1760,12 @@ bretonnian_virtue_20 = {
 	icon = 7
 	land_morale = 2.0
 }    
+great_city = {
+		icon = 4
+	levy_reinforce_rate = 0.25
+	local_tax_modifier = 0.4
+	levy_size = 0.5
+	garrison_size = 0.4
+	disease_defence = 0.1
+	local_revolt_risk = -0.15
+} 

--- a/common/event_modifiers/wh_nicknames.txt
+++ b/common/event_modifiers/wh_nicknames.txt
@@ -1,0 +1,1156 @@
+#############################################
+# CHARACTER NICKNAMES
+# Independent dukes, kings and emperors only
+#
+# 'factor' is the percentage per year of 
+# gaining the nickname
+#
+#############################################
+
+# TRIGGERED ONLY
+################
+nick_the_fine = {}
+nick_the_monumentally_cruel = {}
+nick_the_incompetent = {}
+nick_the_lawgiver = {}
+nick_the_furious = {}
+nick_the_opulent = {} #Jurgen the Drakwald emperor
+nick_the_unjust = {}
+nick_the_tyrannical = {}
+nick_the_stout = {}
+nick_the_lawless = {}
+nick_the_besieger = {}
+nick_the_black = {}
+nick_the_bloody = {}
+nick_the_uniter = {} #Giles le Breton
+nick_the_enormous = {}
+nick_the_jouster = {}
+nick_the_rash = {}
+nick_heldenhammer = {} #Sigmar of course!
+nick_orc_slayer = {}
+nick_dragon_slayer = {}
+nick_skavenslayer = {} #Mandred Skavenskayer
+nick_the_witch_king = {} #Malekith
+nick_the_red_duke = {}
+nick_the_blade = {}
+nick_the_black_prince = {}
+nick_the_bloodytooth = {}
+nick_the_unrelenting = {}
+nick_the_monster = {}
+nick_the_silver_hook = {}
+nick_the_ancient = {}
+nick_the_everliving = {}
+nick_the_father_of_vampires = {}
+nick_the_immortal = {}
+nick_the_colossal = {}
+nick_the_upright = {}
+nick_the_sister_of_twilight = {}
+nick_the_scabrous = {}
+nick_the_imperial_scribe = {}
+nick_the_grand_generaless = {}
+nick_the_rampant_tiger = {}
+nick_the_big_bad_gobbo = {}
+nick_the_small_wonder = {}
+nick_the_heavenly_master = {}
+nick_the_damoiselle_de_guerre = {}
+
+#Generally Kislevite
+nick_radii = {}
+nick_ursus = {}
+
+#Generally Wood Elf
+nick_the_nighthawk = {}
+nick_the_parted_veil = {}
+nick_the_hooked_blade = {}
+nick_the_masque = {}
+
+nick_ironbark = {}
+nick_doomstar = {}
+
+#Generally High Elf
+nick_the_defender = {} #Aenarion
+nick_the_explorer = {} #Bel Shanaar
+nick_the_warrior = {} #Caledor II (Caledor I known as The Conqueror, a vanilla nickname)
+nick_the_peacemaker = {} #Caradryel
+nick_the_slayer = {} #Tethlis
+nick_the_scholar = {} #Bel-Korhadris
+nick_the_poet = {} #Aethis
+nick_the_impetuous = {} #Morvael
+nick_the_sage = {} #Bel-Hathor
+nick_the_seafarer = {} #Finubar
+nick_the_radiant = {}
+nick_the_silver = {}
+
+#Generally Dwarf
+nick_whitebeard = {} #Snorri, who was friends with Malekith
+nick_starbreaker = {} #Gotrek, declared War of Vengeance
+nick_blackbeard = {} #Mogrim
+nick_proudbeard = {} #Logan
+nick_ironbeard = {} #Kurgan, saved by Sigmar
+nick_sourscowl = {} #Finn
+nick_halfhand = {} #Snorri son of Gotrek Starbreaker, THERE IS ALREADY A nick_half_hand in vanilla
+nick_grudgebearer = {} #Thorgrim, and presumably any very angry dwarf
+nick_ironhammer = {}
+nick_hammerfist = {}
+nick_irongrip = {}
+nick_stormcrow = {}
+nick_stoneanvil = {}
+nick_blueaxe = {}
+nick_scarface = {}
+nick_ironhelm = {}
+nick_giftgiver = {}
+nick_axehelm = {}
+nick_oath_holder = {}
+nick_orcbane = {}
+nick_bronze_bandages = {}
+nick_sharpedge = {}
+nick_greybeard = {}
+nick_strongwill = {}
+nick_deathdealer = {}
+nick_oakenshield = {}
+nick_thunderhorn = {}
+
+#Generally Chaos
+nick_the_gloried = {
+	allow = {
+		age = 25
+		OR = {
+		trait = everchosen
+		trait = chaos_chosen
+		}
+	}
+	chance = {
+		factor = 2
+	}
+} #Kharduun the Everchosen
+nick_the_righteous = {}
+nick_the_black_iron_reaver = {} #Mortkin
+nick_the_magnificent = {}
+nick_the_maggot_lord = {
+	allow = {
+		age = 50
+		OR = {
+		trait = prince_nurgle
+		trait = chosen_nurgle
+		}
+	}
+	chance = {
+		factor = 2
+	}
+}
+nick_the_tainted = {
+	allow = {
+		age = 20
+		religion = nurgle
+	}
+	chance = {
+		factor = 1
+	}
+}
+nick_the_changer = {
+	allow = {
+		age = 50
+		OR = {
+		trait = prince_tzeentch
+		trait = chosen_tzeentch
+		}
+	}
+	chance = {
+		factor = 2
+	}
+}
+nick_the_leechlord = {
+	allow = {
+		age = 50
+		OR = {
+		trait = prince_nurgle
+		trait = chosen_nurgle
+		}
+	}
+	chance = {
+		factor = 2
+	}
+}
+nick_the_curseling = {
+	allow = {
+		age = 50
+		OR = {
+		trait = champion_tzeentch
+		trait = chosen_tzeentch
+		}
+	}
+	chance = {
+		factor = 1
+	}
+}
+nick_the_wanderer = {}
+nick_the_undefeated = {} #Arbaal
+nick_the_denied_one = {} #Dechala
+nick_the_khorngor = {
+	allow = {
+		age = 25
+		religion = khorne
+		trait = creature_beastman
+	}
+	chance = {
+		factor = 1
+	}
+}#Beastman
+nick_the_tzaangor = {
+	allow = {
+		age = 25
+		religion = tzeentch
+		trait = creature_beastman
+	}
+	chance = {
+		factor = 1
+	}
+}#Beastman
+nick_the_slaangor = {
+	allow = {
+		age = 25
+		religion = slaanesh
+		trait = creature_beastman
+	}
+	chance = {
+		factor = 1
+	}
+}#Beastman
+nick_the_pestigor = {
+	allow = {
+		age = 25
+		religion = nurgle
+		trait = creature_beastman
+	}
+	chance = {
+		factor = 1
+	}
+}#Beastman
+nick_the_depraved = {
+	allow = {
+		age = 20
+		religion = slaanesh
+	}
+	chance = {
+		factor = 1
+	}
+}
+nick_the_blooded_one = {
+	allow = {
+		age = 50
+		OR = {
+		trait = champion_khorne
+		trait = chosen_khorne
+		}
+	}
+	chance = {
+		factor = 2
+	}
+}
+nick_the_serpent = {
+	allow = {
+		age = 35
+		OR = {
+		trait = prince_slaanesh
+		trait = chosen_slaanesh
+		trait = champion_slaanesh
+		}
+	}
+	chance = {
+		factor = 2
+	}
+} #Slaaneshi
+nick_the_rager = {
+    allow = {
+	    age = 16
+	    NOT = { trait = infirm }
+	    NOT = { trait = incapable }
+	    NOT = { trait = patient }
+	    NOT = { trait = kind }
+	    NOT = { trait = charitable }
+	}
+	chance = {
+		factor = 1
+	}
+}
+nick_the_scaled = {
+	allow = {
+		age = 16
+		trait = mut_scales
+	}
+	chance = {
+		factor = 1
+	}
+} #Scaled mutation
+nick_the_twisted = {
+	allow = {
+		age = 16
+		OR = {
+		trait = mut_spines
+		trait = mut_horns
+		trait = mut_scales
+		trait = mut_thirdeye
+		trait = mut_tongue
+		trait = mut_crests
+		trait = mut_doublehead
+		trait = mut_beak
+		trait = mut_teeth
+		trait = mut_eyes
+		trait = mut_bigeyes
+		}
+	}
+	chance = {
+		factor = 1
+	}
+} #Mutated
+nick_the_gifted = {
+	allow = {
+		age = 16
+		OR = {
+		trait = mut_spines
+		trait = mut_horns
+		trait = mut_scales
+		trait = mut_thirdeye
+		trait = mut_tongue
+		trait = mut_crests
+		trait = mut_doublehead
+		trait = mut_beak
+		trait = mut_teeth
+		trait = mut_eyes
+		trait = mut_bigeyes
+		}
+	}
+	chance = {
+		factor = 1
+	}
+} #Mutated
+nick_the_gazed_upon = {
+	allow = {
+		age = 16
+		OR = {
+		trait = mut_spines
+		trait = mut_horns
+		trait = mut_scales
+		trait = mut_thirdeye
+		trait = mut_tongue
+		trait = mut_crests
+		trait = mut_doublehead
+		trait = mut_beak
+		trait = mut_teeth
+		trait = mut_eyes
+		trait = mut_bigeyes
+		}
+	}
+	chance = {
+		factor = 1
+	}
+} #Mutated
+nick_the_god_shaped = {
+	allow = {
+		age = 16
+		OR = {
+		trait = mut_spines
+		trait = mut_horns
+		trait = mut_scales
+		trait = mut_thirdeye
+		trait = mut_tongue
+		trait = mut_crests
+		trait = mut_doublehead
+		trait = mut_beak
+		trait = mut_teeth
+		trait = mut_eyes
+		trait = mut_bigeyes
+		}
+	}
+	chance = {
+		factor = 1
+	}
+} #Mutated
+nick_of_the_third_eye = {
+	allow = {
+		age = 16
+		trait = mut_thirdeye
+	}
+	chance = {
+		factor = 1
+	}
+} #Third eye mutation
+nick_the_many_eyed = {
+	allow = {
+		age = 16
+		trait = mut_eyes
+	}
+	chance = {
+		factor = 1
+	}
+} #Many eyes mutation
+nick_snaketongue = {
+	allow = {
+		age = 16
+		trait = mut_tongue
+	}
+	chance = {
+		factor = 1
+	}
+} #Tongue mutation
+nick_the_beaked = {
+	allow = {
+		age = 16
+		trait = mut_beak
+	}
+	chance = {
+		factor = 1
+	}
+} #Beak mutation
+nick_the_favoured = {
+	allow = {
+		age = 16
+		OR = {
+		trait = champion_khorne
+		trait = champion_tzeentch
+		trait = champion_nurgle
+		trait = champion_slaanesh
+		trait = chosen_khorne
+		trait = chosen_tzeentch
+		trait = chosen_nurgle
+		trait = chosen_slaanesh
+		}
+		OR = {
+		trait = mut_spines
+		trait = mut_horns
+		trait = mut_scales
+		trait = mut_thirdeye
+		trait = mut_tongue
+		trait = mut_crests
+		trait = mut_doublehead
+		trait = mut_beak
+		trait = mut_teeth
+		trait = mut_eyes
+		trait = mut_bigeyes
+		}
+	}
+	chance = {
+		factor = 2
+	}
+} #Mutation
+nick_the_eternal = {
+	allow = {
+		age = 50
+		NOT = { trait = infirm }
+		NOT = { trait = incapable }
+		OR = {
+			trait = prince_khorne
+			trait = prince_slaanesh
+			trait = prince_tzeentch
+			trait = prince_nurgle
+		}
+	}
+	chance = {
+		factor = 2
+	}
+}
+nick_the_brasslord = {
+    allow = {
+	    age = 50
+		NOT = { trait = infirm }
+		NOT = { trait = incapable }
+		NOT = { trait = craven }
+		religion = khorne
+		OR = {
+		    trait = champion_khorne
+			trait = chosen_khorne
+			trait = prince_khorne
+		}
+	}
+	chance = {
+		factor = 2
+	}
+}
+
+nick_bloodaxe = {
+    allow = {
+	    age = 20
+		religion = khorne
+	    NOT = { trait = patient }
+	    NOT = { trait = kind }
+	    NOT = { trait = charitable }
+	}
+	chance = {
+		factor = 1
+	}
+}
+
+nick_the_weak = {
+    allow = {
+	    age = 20
+		religion = khorne
+		NOT = { trait = wroth }
+		NOT = { trait = cruel }
+	    OR = {
+		trait = patient
+	    trait = kind
+		trait = weak
+		}
+	}
+	chance = {
+		factor = 1
+	}
+}
+
+nick_the_soft = {
+    allow = {
+	    age = 20
+		religion = khorne
+		NOT = { trait = wroth }
+		NOT = { trait = cruel }
+	    OR = {
+		trait = patient
+	    trait = kind
+		trait = soft
+		}
+	}
+	chance = {
+		factor = 1
+	}
+}
+
+nick_the_changeling = {
+    allow = {
+	    age = 20
+		religion = tzeentch
+		NOT = { trait = prince_tzeentch }
+	    OR = {
+		trait = lore_tzeentch
+	    trait = chosen_tzeentch
+		trait = champion_tzeentch
+		}
+	}
+	chance = {
+		factor = 1
+	}
+}
+nick_daemonclaw = {}
+nick_blackstaff = {}
+nick_goldenrod = {}
+nick_hammerstorm = {}
+nick_one_eye = {}
+nick_flameaxe = {
+    allow = {
+	    age = 20
+	    OR = {
+		culture_group = norscan_group
+		culture_group = hung_group
+		culture_group = kurgan_group
+		}
+		NOT = {
+		religion_group = old_world_group
+		}
+	}
+	chance = {
+		factor = 1
+	}
+}
+nick_wartooth = {
+    allow = {
+	    age = 20
+	    OR = {
+		culture_group = norscan_group
+		culture_group = hung_group
+		culture_group = kurgan_group
+		culture_group = beastman_group
+		}
+		NOT = {
+		religion_group = old_world_group
+		}
+	}
+	chance = {
+		factor = 1
+	}
+}
+nick_the_forsaken = {
+    allow = {
+	    age = 20
+	    trait = creature_chaosspawn
+	}
+	chance = {
+		factor = 2
+	}
+}
+
+
+#Generally Dark Elf
+nick_the_crone = {}
+nick_the_hag = {}
+nick_the_overlord = {}
+nick_the_scorned = {}
+nick_the_plunderer = {}
+nick_the_sorceress = {}
+nick_the_witch = {}
+nick_the_siegemaster = {}
+nick_the_tormentor = {}
+
+nick_darkblade = {} #Nickname given to Dark Elf bastards
+nick_bloodrider = {}
+nick_bloodshade = {}
+nick_drakebreaker = {}
+nick_blacksaber = {}
+nick_skulltaker = {}
+nick_dreadshot = {}
+nick_dreadblade = {}
+nick_dragonbane = {}
+nick_darkmere = {}
+nick_darksoul = {}
+nick_deathtalon = {}
+nick_sourblood = {}
+nick_vilesong = {}
+nick_darkmane = {}
+nick_dreadbringer = {}
+nick_blackfire = {}
+nick_fellshard = {}
+nick_blackhand = {}
+nick_darkwhisper = {}
+nick_darkseed = {}
+nick_mournblade = {}
+nick_manslayer = {}
+nick_doombringer = {}
+nick_fellblade = {}
+nick_deepwatcher = {}
+nick_bloodsinger = {}
+nick_redspear = {}
+nick_blackheart = {}
+nick_blackstar = {}
+nick_shadowstalker = {}
+
+
+#Generally Beastman
+nick_the_black_tailed = {
+	allow = {
+		age = 25
+		trait = creature_beastman
+	}
+	chance = {
+		factor = 1
+	}
+}#Beastman
+nick_the_ruinous= {
+    allow = {
+	    age = 20
+	    OR = {
+		culture_group = norscan_group
+		culture_group = hung_group
+		culture_group = kurgan_group
+		culture_group = beastman_group
+		}
+		OR = {
+		religion = khorne
+		religion = chaos
+		}
+	}
+	chance = {
+		factor = 1
+	}
+}
+nick_the_black_mawed= {
+	allow = {
+		age = 25
+		trait = creature_beastman
+	}
+	chance = {
+		factor = 1
+	}
+}#Beastman
+nick_the_fiendish = {
+	allow = {
+		age = 25
+		trait = creature_beastman
+	}
+	chance = {
+		factor = 1
+	}
+}#Beastman
+nick_the_raider = {}
+nick_the_maker = {}
+nick_the_festering= {
+    allow = {
+	    age = 20
+	    religion = nurgle
+	}
+	chance = {
+		factor = 1
+	}
+}
+nick_the_luxuriant = {}
+nick_the_despoiler= {
+    allow = {
+	    age = 20
+	    OR = {
+		culture_group = norscan_group
+		culture_group = hung_group
+		culture_group = kurgan_group
+		culture_group = beastman_group
+		}
+		NOT = {
+		religion_group = old_world_group
+		}
+	}
+	chance = {
+		factor = 1
+	}
+}
+nick_the_unbreakable = {}
+nick_the_foul_mawed = {
+	allow = {
+		age = 25
+		trait = creature_beastman
+	}
+	chance = {
+		factor = 1
+	}
+}#Beastman
+nick_the_fouler = {
+	allow = {
+		age = 25
+		trait = creature_beastman
+	}
+	chance = {
+		factor = 1
+	}
+}#Beastman
+nick_the_bloody_mawed = {
+	allow = {
+		age = 25
+		trait = creature_beastman
+	}
+	chance = {
+		factor = 1
+	}
+}#Beastman
+nick_the_foul = {
+	allow = {
+		age = 25
+		trait = creature_beastman
+	}
+	chance = {
+		factor = 1
+	}
+}#Beastman
+nick_the_thirster = {
+	allow = {
+		age = 25
+		trait = creature_beastman
+	}
+	chance = {
+		factor = 1
+	}
+}#Beastman
+nick_clawhand = {
+	allow = {
+		age = 25
+		trait = creature_beastman
+	}
+	chance = {
+		factor = 1
+	}
+}#Beastman
+nick_bloody_horn = {
+	allow = {
+		age = 25
+		trait = creature_beastman
+	}
+	chance = {
+		factor = 1
+	}
+}#Beastman
+nick_short_horn = {
+	allow = {
+		age = 25
+		trait = creature_beastman
+	}
+	chance = {
+		factor = 1
+	}
+}#Beastman
+nick_greymane = {
+	allow = {
+		age = 25
+		trait = creature_beastman
+	}
+	chance = {
+		factor = 1
+	}
+}#Beastman
+nick_fel_horn = {
+	allow = {
+		age = 25
+		trait = creature_beastman
+	}
+	chance = {
+		factor = 1
+	}
+}#Beastman
+nick_blood_fang = {
+	allow = {
+		age = 25
+		trait = creature_beastman
+	}
+	chance = {
+		factor = 1
+	}
+}#Beastman
+nick_blood_claw = {
+	allow = {
+		age = 25
+		trait = creature_beastman
+	}
+	chance = {
+		factor = 1
+	}
+}#Beastman
+nick_bloodpelt = {
+	allow = {
+		age = 25
+		trait = creature_beastman
+	}
+	chance = {
+		factor = 1
+	}
+}#Beastman
+nick_the_shadowgave = {
+	allow = {
+		age = 25
+		trait = creature_beastman
+	}
+	chance = {
+		factor = 1
+	}
+}#Beastman
+
+#Jungle Creature Nicks
+nick_the_razorback = {}
+nick_the_cold_one = {}
+nick_the_terradon = {}
+nick_the_stegadon = {}
+nick_the_sauropod = {}
+nick_the_thunder_lizard = {}
+nick_the_carnosaur = {}
+
+#Lizardmen
+nick_the_deliverer = {}
+nick_the_slithering = {} 
+nick_the_glorious = {} 
+nick_the_greatcoatl = {} 
+nick_the_keeper = {} 
+nick_the_herald = {} 
+nick_the_prophet = {}
+
+#Generally Khemri
+nick_the_imperishable = {}
+
+#Skaven
+nick_doomclaw = {}
+nick_the_vast = {}
+nick_mancarver = {}
+nick_ironscratch = {}
+
+#Generally Greenskin
+nick_blakhand = {}
+
+nick_the_biggest = {
+	allow = {
+		age = 16
+		NOT = { trait = infirm }
+		NOT = { trait = incapable }
+		OR = {
+			trait = orc_large
+			trait = orc_huge
+			trait = goblin_large
+			trait = goblin_huge
+			trait = tall
+		}
+		OR = {
+			culture_group = orc_group
+			culture_group = goblin_group
+		}
+	}
+	chance = {
+		factor = 1
+	}
+}
+
+nick_the_mangla = {
+	allow = {
+		age = 16
+		OR = {
+			culture_group = orc_group
+			culture_group = goblin_group
+		}
+		OR = {
+			trait = wroth
+			trait = aggressive_leader
+			trait = impaler
+		}
+	}
+	chance = {
+		factor = 1
+	}
+}
+
+nick_the_crusha = {
+	allow = {
+		age = 16
+		OR = {
+			culture_group = orc_group
+			culture_group = goblin_group
+		}
+		OR = {
+			trait = wroth
+			trait = aggressive_leader
+		}
+	}
+	chance = {
+		factor = 1
+	}
+}
+
+nick_the_baddest = {
+	allow = {
+		age = 16
+		OR = {
+			culture_group = orc_group
+			culture_group = goblin_group
+		}
+		NOT = {
+			trait = weak
+			trait = shy
+			trait = sickly
+		}
+		OR = {
+			trait = arbitrary
+			trait = cruel
+		}
+	}
+	chance = {
+		factor = 1
+	}
+}
+
+nick_the_strongest = {
+	allow = {
+		age = 16
+		OR = {
+			culture_group = orc_group
+			culture_group = goblin_group
+		}
+		NOT = {
+			trait = weak
+			trait = shy
+			trait = sickly
+		}
+		OR = {
+			trait = hardy
+			trait = strong
+			martial = 20
+		}
+	}
+	chance = {
+		factor = 1
+	}
+}
+
+nick_the_runt = {
+	allow = {
+		age = 15
+		trait = dwarf
+		OR = {
+			culture_group = orc_group
+			culture_group = goblin_group
+		}
+	}
+	chance = {
+		factor = 1
+		
+		
+		modifier = {
+			factor = 1.5
+			NOT = { prestige = 10 }
+		}
+	}
+}
+
+nick_the_cunnin = {
+	allow = {
+		age = 20
+		ruled_years = 5
+		NOT = { trait = infirm }
+		NOT = { trait = incapable }
+		OR = {
+			culture_group = orc_group
+			culture_group = goblin_group
+		}
+		OR = {
+			trait = trickster
+			trait = experimenter
+		}
+		OR = {
+			trait = deceitful
+			trait = quick
+			trait = genius
+		}
+	}
+	chance = {
+		factor = 1
+	}
+}
+
+nick_the_sneaky = {
+	allow = {
+		ruled_years = 10
+		intrigue = 12
+		OR = {
+			culture_group = orc_group
+			culture_group = goblin_group
+		}
+		NOT = {
+			trait = wroth
+		}
+		OR = {
+			trait = elusive_shadow
+			trait = intricate_webweaver
+		}
+		OR = {
+			trait = deceitful
+			trait = patient
+		}
+	}
+	chance = {
+		factor = 1
+	}
+}
+
+nick_the_stompa = {
+	allow = {
+		trait = brave
+		OR = {
+			culture_group = orc_group
+			culture_group = goblin_group
+		}
+		martial = 14
+		OR = {
+			trait = skilled_tactician
+			trait = brilliant_strategist
+		}
+	}
+	chance = {
+		factor = 1
+	}
+}
+
+##Monster Hunter Nicknames
+#Daemons
+nick_the_daemonslayer = {} #For dwarves
+nick_the_daemonsbane = {} #For elves
+nick_the_daemonkiller = {}
+
+nick_the_blooddrainer = {}
+nick_the_peacebringer = {}
+nick_the_pacifier = {}
+nick_the_brassbeatah = {} #Greenskins only
+
+nick_the_purifier = {}
+nick_the_grimdoctor = {} #Imperials only
+nick_the_snotcleanah = {} #Orcs only
+
+nick_the_sanctifier = {}
+nick_the_tongueslasher = {}
+nick_the_pinksplattah =  {} #Orcs only
+
+nick_the_orderbringer = {}
+nick_the_crowsbane = {}
+nick_the_pluckerer = {} #Orcs only
+
+#Slann killer
+nick_the_destroyer = {} #Only one for elves
+nick_the_toadsbane = {}
+nick_the_frogsmashah = {} #Orcs only
+
+#Forest Spirit/Treekin killer
+nick_the_misbegotten = {} #Only one for elves
+nick_the_lumberjack = {}
+nick_the_treesbane = {}
+nick_the_arsonist = {}
+nick_the_bushcuttah = {} #Orcs only
+
+#Vampires
+nick_the_vampireslayer = {}
+nick_the_nightguardian = {}
+nick_the_moonhunter = {}
+nick_the_paleman = {}
+nick_the_leecher = {}
+nick_the_ashmonger = {}
+nick_the_firebringer = {}
+nick_the_cleanser = {}
+nick_burntskin = {}
+nick_cat_steps = {}
+nick_the_silent = {}
+nick_the_nighteye = {}
+nick_the_redcape = {}
+nick_the_beautiful_sun = {}
+
+nick_the_bonegnashah = {} #Orcs only
+nick_the_redpaintah = {} #Orcs only
+nick_the_fangbreakah = {} #Orcs only
+nick_the_toothbrushah = {} #Orcs only
+nick_the_vampsquashah = {} #Orcs only
+
+###Generally Pirate
+nick_the_flying_culturename = {}
+nick_the_red_sailor = {}
+nick_the_black_sailor = {}
+nick_ghostsails = {}
+nick_searat = {}
+nick_seadog = {}
+nick_seawolf = {}
+nick_blackbeard = {}
+nick_redbeard = {}
+nick_whitebeard = {}
+nick_board_thunder = {}
+nick_the_scourge_capital = {}
+nick_lazyjacks = {}
+nick_crossbones = {}
+nick_grogswiller = {}
+
+###Generally Everchosen
+nick_the_brazen = {}
+nick_the_eviscerator = {}
+nick_the_betrayer = {}
+nick_the_reviled = {}
+nick_the_neverborn = {}
+nick_the_soulless = {}
+nick_the_golden = {}
+nick_the_faithless = {}
+nick_the_eternal = {}
+nick_the_thousandeyed = {}
+nick_the_warpbound = {}
+nick_the_wyrd = {}
+nick_the_anointed = {}
+
+###Traits
+
+nick_the_lunatic = {
+
+	allow = {
+		age = 40
+		ruled_years = 20
+		trait = lunatic_3
+		NOR = { trait = vampire_carstein_visible
+			trait = vampire_strigoi_visible
+			trait = vampire_lahmian_visible
+			trait = vampire_necrarch_visible
+			trait = vampire_jade_visible
+			trait = vampire_mahtmasi_visible
+			trait = vampire_blood_visible }
+	}
+	chance = {
+		factor = 2
+	}
+}


### PR DESCRIPTION
1. geheimnisnacht\common\event_modifiers\warhammer_modifiers.txt 
В файле внесен модификатор провинции great_city накладывающийся на провинцию Lahmia после выполнения решения по реконструкции города.

2. geheimnisnacht\common\nicknames\wh_nicknames.txt  
Добавлено прозвище "Прекрасное Солнце" (beautiful_sun) Неферате, выдаваемое после выполнения решения о возвращении в Ламию.

3. geheimnisnacht\localisation\BR_lahmia.csv
Файл локализации на модификатор,прозвище, эвенты и решения. Пока что написал лишь на английском, по мере необходимости будет на русском (в руссификаторе из отдельной темы).

4.  geheimnisnacht\decisions\BR_lahmian_decisions.txt
Доработанный файл решений, добавлено 3 решения: 2 связанные с государством (retake_lahmia даёт честь, престиж, перемещает столицу в провинцию Ламия, стоит 2500золотых; rebuild_palace_and_blood_temple дает модификатор great_city, честь, престиж, стоит 1500 золотых); третье решение позволяет очищать захваченные у нехекхаранов провинции от "Проклятья песков", но только за 200 монет (дорогой ритуал) за провинцию и умении некромантии (lore_necromancy), ведь только некроманты знают как диспелить заклинания других некромантов.

5. geheimnisnacht\events\BR_lahmian_events.txt
Доработаны эвенты, а именно внесено два эвента связанных с пунктом 4: lahmia.395 эвент на подтверждение очищения провинции от проклятия, с двумя опциями (Да, Нет). При выборе "Да" снимается 200 монет (ритуал), снимается 50 чести (магия некромантии как ни крути), дается 100 престижа (способный маг,умеющий в некромантию). При выборе "Нет" снимается престиж (типа струсил) и дается 5 ед чести (воздержался от магии некромантии); lahmia.396 эвент подтверждающий успех. Провала не может быть,потому что это диспел заклинания, который мало мальски некромант (некромант!) умеет делать без ошибок, эффект от успеха в виде снятого модификатора "Проклятие песков", заселение провинции культурой, которой принадлежит правитель-некромант, и религия соответственно (как в случае с орками).